### PR TITLE
Remove logic to publish to Github Packages

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -33,8 +32,6 @@ jobs:
           ./gradlew publish-sdk-module-${{ env.NAME }} --continue
         env:
           NAME: ${{ steps.get-name.outputs.name }}
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,6 @@ sdkModules.forEach {
             it.tasks.findByName("publishToMavenCentral")?.let {
                 dependsOn(it)
             }
-            it.tasks.findByName("publishMavenPublicationToGithubPackagesRepository")?.let {
-                dependsOn(it)
-            }
         }
     }
 }

--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/ConfiguresMavenPublish.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/ConfiguresMavenPublish.kt
@@ -4,10 +4,7 @@ import com.tidal.sdk.plugins.constant.PluginId
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
-import java.net.URI
 import org.gradle.api.Project
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPomLicense
 import org.gradle.kotlin.dsl.configure
 
@@ -16,10 +13,6 @@ internal class ConfiguresMavenPublish : (Project) -> Unit {
     override fun invoke(target: Project): Unit = with(target) {
         pluginManager.apply(PluginId.GRADLE_MAVEN_PUBLISH_PLUGIN_ID)
         ConfiguresGradleProjectVersion()(this)
-
-        configure<PublishingExtension> {
-            repositories.addGithubPackages()
-        }
 
         configure<MavenPublishBaseExtension> {
             setPublishJavadoc(this@with, false)
@@ -74,17 +67,6 @@ internal class ConfiguresMavenPublish : (Project) -> Unit {
 
     private fun String.toArtifactId(): String {
         return substring(1).replace(':', '-')
-    }
-
-    private fun RepositoryHandler.addGithubPackages() {
-        maven {
-            name = "GithubPackages"
-            url = URI.create("https://maven.pkg.github.com/${System.getenv("GITHUB_REPOSITORY")}")
-            credentials {
-                username = System.getenv("GITHUB_USER")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 
     private fun MavenPomLicense.apache() {


### PR DESCRIPTION
We will now only publish to MavenCentral.

This removes
- the dependency on `publishMavenPublicationToGithubPackagesRepository`
- the GH packages repo setup
- the obsolete env vars