### PR TITLE
Remove no-longer necessary use of GitHub secrets

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,8 +14,6 @@ jobs:
   expose-tag:
     name: Expose Tag
     runs-on: ubuntu-latest
-    env:
-      ORG_GRADLE_PROJECT_githubToken: ${{ secrets.pat }}
     outputs:
       module-tag: ${{ steps.expose-tag.outputs.tag }}
       module-version: ${{ steps.expose-tag.outputs.version }}

--- a/.github/workflows/fossa-scan.yml
+++ b/.github/workflows/fossa-scan.yml
@@ -7,8 +7,6 @@ on:
         required: true
       fossaApiKey:
         required: true
-env:
-  ORG_GRADLE_PROJECT_githubToken: ${{ secrets.pat }}
 
 jobs:
   fossa-scan:

--- a/.github/workflows/instrumented-test.yml
+++ b/.github/workflows/instrumented-test.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   run-instrumented-tests:
     runs-on: ubuntu-latest
-    env:
-      ORG_GRADLE_PROJECT_githubToken: ${{ secrets.pat }}
     name: Run instrumented tests
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,6 @@ on:
       pat:
         required: true
 
-env:
-  ORG_GRADLE_PROJECT_githubToken: ${{ secrets.pat }}
-
 jobs:
   run-ktlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -15,7 +15,6 @@ jobs:
       modules: ${{ steps.build-matrix.outputs.modules}}
     env:
       REF_BEFORE: ${{ github.event.before }}
-      ORG_GRADLE_PROJECT_githubToken: ${{ secrets.pat }}
     steps:
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -12,7 +12,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     env:
-      ORG_GRADLE_PROJECT_githubToken: ${{ secrets.PACKAGES_PAT }}
       PATH_CLONE_WORK: ${{ github.workspace }}/${{ github.repository }}
       PATH_CLONE_SUPPORT: ${{ github.workspace }}/support
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  ORG_GRADLE_PROJECT_githubToken: ${{ secrets.PACKAGES_PAT }}
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,9 +5,6 @@ on:
       pat:
         required: true
 
-env:
-  ORG_GRADLE_PROJECT_githubToken: ${{ secrets.pat }}
-
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,21 +12,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        tidalMusicGithub("tidal-sdk-android")
         maven {
             url = uri("https://jitpack.io")
-        }
-    }
-}
-
-fun RepositoryHandler.tidalMusicGithub(repository: String) {
-    maven(url = "https://maven.pkg.github.com/tidal-music/$repository/") {
-        credentials(HttpHeaderCredentials::class) {
-            name = "Authorization"
-            value = "Bearer ${extra["githubToken"]}"
-        }
-        authentication {
-            create<HttpHeaderAuthentication>("Authorization")
         }
     }
 }


### PR DESCRIPTION
This is because now everything is published on Central.