### PR TITLE
Ziad/immersive audio param support

### DIFF
--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/DeriveUiState.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/DeriveUiState.kt
@@ -27,6 +27,7 @@ internal class DeriveUiState {
                         streamingAudioQualityWifi,
                         streamingAudioQualityCellular,
                         loudnessNormalizationMode,
+                        immersiveAudio,
                         current,
                         next,
                         player.playbackEngine.playbackState,

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivity.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivity.kt
@@ -116,6 +116,9 @@ internal class MainActivity : ComponentActivity() {
                                         Impure.SetLoudnessNormalizationMode(it),
                                     )
                                 },
+                                dispatchSetImmersiveAudio = {
+                                    dispatch(Impure.SetImmersiveAudio(it))
+                                },
                                 dispatchRelease = { dispatch(Impure.Release) },
                                 dispatchSetSnackbarMessage = {
                                     dispatch(Impure.SetSnackbarMessage(it))

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityScreen.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityScreen.kt
@@ -37,6 +37,7 @@ internal fun MainActivityScreen(
     dispatchSetAudioQualityOnWifi: (AudioQuality) -> Unit,
     dispatchSetAudioQualityOnCell: (AudioQuality) -> Unit,
     dispatchSetLoudnessNormalizationMode: (LoudnessNormalizationMode) -> Unit,
+    dispatchSetImmersiveAudio: (Boolean) -> Unit,
     dispatchRelease: () -> Unit,
     dispatchSetSnackbarMessage: (String?) -> Unit,
     dispatchCreatePlayerWithExternalCache: (Context, Boolean) -> Unit,
@@ -75,6 +76,7 @@ internal fun MainActivityScreen(
                 dispatchSetAudioQualityOnWifi,
                 dispatchSetAudioQualityOnCell,
                 dispatchSetLoudnessNormalizationMode,
+                dispatchSetImmersiveAudio,
                 dispatchRelease,
             )
 

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityState.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityState.kt
@@ -26,6 +26,7 @@ internal sealed class MainActivityState private constructor() {
         val streamingAudioQualityOnWifi: AudioQuality,
         val streamingAudioQualityOnCell: AudioQuality,
         val loudnessNormalizationMode: LoudnessNormalizationMode,
+        val immersiveAudio: Boolean,
         val currentMediaProduct: MediaProduct?,
         val nextMediaProduct: MediaProduct?,
         val playbackState: PlaybackState,

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModel.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModel.kt
@@ -249,6 +249,7 @@ internal class MainActivityViewModel(context: Context) : ViewModel() {
                                 player.playbackEngine.streamingWifiAudioQuality,
                                 loudnessNormalizationMode = player.playbackEngine
                                     .loudnessNormalizationMode,
+                                immersiveAudio = player.playbackEngine.immersiveAudio
                             )
                         }
 
@@ -368,6 +369,16 @@ internal class MainActivityViewModel(context: Context) : ViewModel() {
                     state.player.playbackEngine.loudnessNormalizationMode =
                         loudnessNormalizationMode
                     return state.copy(loudnessNormalizationMode = loudnessNormalizationMode)
+                }
+            }
+
+            class SetImmersiveAudio(
+                private val immersiveAudio: Boolean,
+            ) : Impure<PlayerInitialized, PlayerInitialized>() {
+
+                override suspend operator fun invoke(state: PlayerInitialized): PlayerInitialized {
+                    state.player.playbackEngine.immersiveAudio = immersiveAudio
+                    return state.copy(immersiveAudio = immersiveAudio)
                 }
             }
 

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModelState.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModelState.kt
@@ -61,5 +61,6 @@ internal sealed class MainActivityViewModelState private constructor() {
         val streamingAudioQualityWifi: AudioQuality,
         val streamingAudioQualityCellular: AudioQuality,
         val loudnessNormalizationMode: LoudnessNormalizationMode,
+        val immersiveAudio: Boolean,
     ) : MainActivityViewModelState()
 }

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/PlayerInitializedScreen.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/PlayerInitializedScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -26,6 +27,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -60,6 +62,7 @@ internal fun PlayerInitializedScreen(
     dispatchSetAudioQualityOnWifi: (AudioQuality) -> Unit,
     dispatchSetAudioQualityOnCell: (AudioQuality) -> Unit,
     dispatchSetLoudnessNormalizationMode: (LoudnessNormalizationMode) -> Unit,
+    dispatchSetImmersiveAudio: (Boolean) -> Unit,
     dispatchRelease: () -> Unit,
 ) {
     Column(Modifier.padding(paddingValues)) {
@@ -104,6 +107,7 @@ internal fun PlayerInitializedScreen(
                 dispatchSetAudioQualityOnWifi,
                 dispatchSetAudioQualityOnCell,
                 dispatchSetLoudnessNormalizationMode,
+                dispatchSetImmersiveAudio,
                 dispatchRelease,
             )
         }
@@ -180,6 +184,7 @@ private fun PlaybackControls(
     dispatchSetAudioQualityOnWifi: (AudioQuality) -> Unit,
     dispatchSetAudioQualityOnCell: (AudioQuality) -> Unit,
     dispatchSetLoudnessNormalizationMode: (LoudnessNormalizationMode) -> Unit,
+    dispatchSetImmersiveAudioOnCell: (Boolean) -> Unit,
     dispatchRelease: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -327,6 +332,24 @@ private fun PlaybackControls(
             possibleValues = LoudnessNormalizationMode.values(),
         ) {
             dispatchSetLoudnessNormalizationMode(it)
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "Immersive Audio",
+                modifier = Modifier
+                    .padding(PaddingValues(end = 8F.dp))
+                    .weight(1F, fill = false),
+            )
+            Switch(
+                checked = state.immersiveAudio,
+                onCheckedChange = { dispatchSetImmersiveAudioOnCell(it) },
+            )
         }
         Button(
             onClick = dispatchRelease,

--- a/player/playback-engine/src/androidTest/kotlin/com/tidal/sdk/player/playbackengine/SingleHandlerPlaybackEngineHandlerPostOrThrowTest.kt
+++ b/player/playback-engine/src/androidTest/kotlin/com/tidal/sdk/player/playbackengine/SingleHandlerPlaybackEngineHandlerPostOrThrowTest.kt
@@ -41,6 +41,7 @@ internal class SingleHandlerPlaybackEngineHandlerPostOrThrowTest {
         override val events = MutableSharedFlow<Event>()
         override var streamingWifiAudioQuality = AudioQuality.HIGH
         override var streamingCellularAudioQuality = AudioQuality.LOW
+        override var immersiveAudio = true
         override var loudnessNormalizationMode = LoudnessNormalizationMode.ALBUM
         override var loudnessNormalizationPreAmp = LOUDNESS_NORMALIZATION_PRE_AMP_DEFAULT
         override var videoSurfaceView: AspectRatioAdjustingSurfaceView? = null

--- a/player/playback-engine/src/androidTest/kotlin/com/tidal/sdk/player/playbackengine/SingleHandlerPlaybackEngineThreadingTest.kt
+++ b/player/playback-engine/src/androidTest/kotlin/com/tidal/sdk/player/playbackengine/SingleHandlerPlaybackEngineThreadingTest.kt
@@ -52,6 +52,8 @@ internal class SingleHandlerPlaybackEngineThreadingTest {
             set(_) = assignThreadAndReleaseLock()
         override var streamingCellularAudioQuality = AudioQuality.LOW
             set(_) = assignThreadAndReleaseLock()
+        override var immersiveAudio = true
+            set(_) = assignThreadAndReleaseLock()
         override var loudnessNormalizationMode = LoudnessNormalizationMode.ALBUM
             set(_) = assignThreadAndReleaseLock()
         override var loudnessNormalizationPreAmp = LOUDNESS_NORMALIZATION_PRE_AMP_DEFAULT

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
@@ -34,6 +34,7 @@ import com.tidal.sdk.player.events.model.UCPlaybackSession
 import com.tidal.sdk.player.events.model.UCPlaybackStatistics
 import com.tidal.sdk.player.events.model.VideoPlaybackSession
 import com.tidal.sdk.player.events.model.VideoPlaybackStatistics
+import com.tidal.sdk.player.playbackengine.audiomode.AudioModeRepository
 import com.tidal.sdk.player.playbackengine.dj.DjSessionManager
 import com.tidal.sdk.player.playbackengine.dj.DjSessionStatus
 import com.tidal.sdk.player.playbackengine.error.ErrorHandler
@@ -82,6 +83,7 @@ internal class ExoPlayerPlaybackEngine(
     private val streamingPrivileges: StreamingPrivileges,
     private val playbackContextFactory: PlaybackContextFactory,
     private val audioQualityRepository: AudioQualityRepository,
+    private val audioModeRepository: AudioModeRepository,
     private val volumeHelper: VolumeHelper,
     private val trueTimeWrapper: TrueTimeWrapper,
     private val eventReporter: EventReporter,
@@ -185,6 +187,12 @@ internal class ExoPlayerPlaybackEngine(
         set(value) {
             volumeHelper.loudnessNormalizationPreAmp = value
             updatePlayerVolume()
+        }
+
+    override var immersiveAudio: Boolean
+        get() = audioModeRepository.immersiveAudio
+        set(value) {
+            audioModeRepository.immersiveAudio = value
         }
 
     private var extendedExoPlayer by Delegates.observable(

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/PlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/PlaybackEngine.kt
@@ -173,4 +173,9 @@ interface Configuration {
      * Get or set [loudnessNormalizationPreAmp] as [Int] to use when playing.
      */
     var loudnessNormalizationPreAmp: Int
+
+    /**
+     * Get or set [immersiveAudio] as [Boolean] to use when playing.
+     */
+    var immersiveAudio: Boolean
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/SingleHandlerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/SingleHandlerPlaybackEngine.kt
@@ -43,6 +43,10 @@ internal class SingleHandlerPlaybackEngine(
         get() = delegate.loudnessNormalizationPreAmp
         set(value) = postOrThrow { delegate.loudnessNormalizationPreAmp = value }
 
+    override var immersiveAudio: Boolean
+        get() = delegate.immersiveAudio
+        set(value) = postOrThrow { delegate.immersiveAudio = value }
+
     override var videoSurfaceView: AspectRatioAdjustingSurfaceView?
         set(value) = postOrThrow { delegate.videoSurfaceView = value }
         get() = delegate.videoSurfaceView

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
@@ -10,6 +10,7 @@ import com.tidal.sdk.player.events.EventReporter
 import com.tidal.sdk.player.events.model.DrmLicenseFetch
 import com.tidal.sdk.player.events.model.EndReason
 import com.tidal.sdk.player.events.model.PlaybackInfoFetch
+import com.tidal.sdk.player.playbackengine.audiomode.AudioModeRepository
 import com.tidal.sdk.player.playbackengine.drm.MediaDrmCallbackExceptionFactory
 import com.tidal.sdk.player.playbackengine.error.ErrorCodeFactory
 import com.tidal.sdk.player.playbackengine.error.ErrorHandler
@@ -42,6 +43,7 @@ internal class StreamingApiRepository(
     private val streamingApi: StreamingApi,
     private val audioQualityRepository: AudioQualityRepository,
     private val videoQualityRepository: VideoQualityRepository,
+    private val audioModeRepository: AudioModeRepository,
     private val trueTimeWrapper: TrueTimeWrapper,
     private val mediaDrmCallbackExceptionFactory: MediaDrmCallbackExceptionFactory,
     private val eventReporter: EventReporter,
@@ -98,6 +100,7 @@ internal class StreamingApiRepository(
                     forwardingMediaProduct.productId.toInt(),
                     audioQualityRepository.streamingQuality,
                     PlaybackMode.STREAM,
+                    audioModeRepository.immersiveAudio,
                     streamingSessionId,
                 )
 

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/audiomode/AudioModeRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/audiomode/AudioModeRepository.kt
@@ -1,0 +1,10 @@
+package com.tidal.sdk.player.playbackengine.audiomode
+
+import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
+
+/**
+ * Repository for getting the [immersiveAudio] to be used in a specific request for [PlaybackInfo].
+ */
+internal class AudioModeRepository(
+    var immersiveAudio: Boolean = true,
+)

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/di/ExoPlayerPlaybackEngineModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/di/ExoPlayerPlaybackEngineModule.kt
@@ -14,6 +14,7 @@ import com.tidal.sdk.player.playbackengine.ExoPlayerPlaybackEngine
 import com.tidal.sdk.player.playbackengine.PlaybackContextFactory
 import com.tidal.sdk.player.playbackengine.PlaybackEngine
 import com.tidal.sdk.player.playbackengine.SingleHandlerPlaybackEngine
+import com.tidal.sdk.player.playbackengine.audiomode.AudioModeRepository
 import com.tidal.sdk.player.playbackengine.dj.DateParser
 import com.tidal.sdk.player.playbackengine.dj.DjSessionManager
 import com.tidal.sdk.player.playbackengine.dj.HlsTagsParser
@@ -142,6 +143,10 @@ internal object ExoPlayerPlaybackEngineModule {
 
     @Provides
     @Singleton
+    fun audioModeRepository() = AudioModeRepository()
+
+    @Provides
+    @Singleton
     fun exoPlayerPlaybackEngine(
         coroutineScope: CoroutineScope,
         extendedExoPlayerFactory: ExtendedExoPlayerFactory,
@@ -151,6 +156,7 @@ internal object ExoPlayerPlaybackEngineModule {
         streamingPrivileges: StreamingPrivileges,
         playbackContextFactory: PlaybackContextFactory,
         audioQualityRepository: AudioQualityRepository,
+        audioModeRepository: AudioModeRepository,
         volumeHelper: VolumeHelper,
         trueTimeWrapper: TrueTimeWrapper,
         eventReporter: EventReporter,
@@ -167,6 +173,7 @@ internal object ExoPlayerPlaybackEngineModule {
         streamingPrivileges,
         playbackContextFactory,
         audioQualityRepository,
+        audioModeRepository,
         volumeHelper,
         trueTimeWrapper,
         eventReporter,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
@@ -32,6 +32,7 @@ import com.tidal.sdk.player.playbackengine.Encryption
 import com.tidal.sdk.player.playbackengine.PlayerLoadErrorHandlingPolicy
 import com.tidal.sdk.player.playbackengine.StreamingApiRepository
 import com.tidal.sdk.player.playbackengine.TidalExtractorsFactory
+import com.tidal.sdk.player.playbackengine.audiomode.AudioModeRepository
 import com.tidal.sdk.player.playbackengine.bts.DefaultBtsManifestFactory
 import com.tidal.sdk.player.playbackengine.cache.DefaultCacheKeyFactory
 import com.tidal.sdk.player.playbackengine.dash.DashManifestFactory
@@ -390,6 +391,7 @@ internal object MediaSourcererModule {
         streamingApi: StreamingApi,
         audioQualityRepository: AudioQualityRepository,
         videoQualityRepository: VideoQualityRepository,
+        audioModeRepository: AudioModeRepository,
         trueTimeWrapper: TrueTimeWrapper,
         mediaDrmCallbackExceptionFactory: MediaDrmCallbackExceptionFactory,
         eventReporter: EventReporter,
@@ -398,6 +400,7 @@ internal object MediaSourcererModule {
         streamingApi,
         audioQualityRepository,
         videoQualityRepository,
+        audioModeRepository,
         trueTimeWrapper,
         mediaDrmCallbackExceptionFactory,
         eventReporter,

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngineTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngineTest.kt
@@ -34,6 +34,7 @@ import com.tidal.sdk.player.events.model.PlaybackStatistics.Payload.Adaptation
 import com.tidal.sdk.player.events.model.PlaybackStatistics.Payload.Stall
 import com.tidal.sdk.player.events.model.PlaybackStatistics.Payload.Stall.Reason
 import com.tidal.sdk.player.events.model.VideoPlaybackSession
+import com.tidal.sdk.player.playbackengine.audiomode.AudioModeRepository
 import com.tidal.sdk.player.playbackengine.dj.DjSessionManager
 import com.tidal.sdk.player.playbackengine.dj.DjSessionStatus
 import com.tidal.sdk.player.playbackengine.dj.HlsTags
@@ -108,6 +109,7 @@ internal class ExoPlayerPlaybackEngineTest {
     private val streamingPrivileges = mock<StreamingPrivileges>()
     private val playbackContextFactory = mock<PlaybackContextFactory>()
     private val audioQualityRepository = mock<AudioQualityRepository>()
+    private val audioModeRepository = mock<AudioModeRepository>()
     private val volumeHelper = mock<VolumeHelper>()
     private val trueTimeWrapper = mock<TrueTimeWrapper>()
     private val eventReporter = mock<EventReporter>()
@@ -136,6 +138,7 @@ internal class ExoPlayerPlaybackEngineTest {
             streamingPrivileges,
             playbackContextFactory,
             audioQualityRepository,
+            audioModeRepository,
             volumeHelper,
             trueTimeWrapper,
             eventReporter,

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
@@ -16,6 +16,7 @@ import com.tidal.sdk.player.events.EventReporter
 import com.tidal.sdk.player.events.model.DrmLicenseFetch
 import com.tidal.sdk.player.events.model.EndReason
 import com.tidal.sdk.player.events.model.PlaybackInfoFetch
+import com.tidal.sdk.player.playbackengine.audiomode.AudioModeRepository
 import com.tidal.sdk.player.playbackengine.drm.MediaDrmCallbackExceptionFactory
 import com.tidal.sdk.player.playbackengine.error.ErrorCodeFactory
 import com.tidal.sdk.player.playbackengine.error.ErrorHandler
@@ -43,6 +44,7 @@ internal class StreamingApiRepositoryTest {
     private val streamingApi = mock<StreamingApi>()
     private val audioQualityRepository = mock<AudioQualityRepository>()
     private val videoQualityRepository = mock<VideoQualityRepository>()
+    private val audioModeRepository = mock<AudioModeRepository>()
     private val trueTimeWrapper = mock<TrueTimeWrapper>()
     private val mediaDrmCallbackExceptionFactory = mock<MediaDrmCallbackExceptionFactory>()
     private val eventReporter = mock<EventReporter>()
@@ -51,6 +53,7 @@ internal class StreamingApiRepositoryTest {
         streamingApi,
         audioQualityRepository,
         videoQualityRepository,
+        audioModeRepository,
         trueTimeWrapper,
         mediaDrmCallbackExceptionFactory,
         eventReporter,
@@ -149,6 +152,7 @@ internal class StreamingApiRepositoryTest {
                             productId.toInt(),
                             productQuality,
                             playbackMode,
+                            false,
                             "streamingSessionId",
                         ),
                     )
@@ -262,6 +266,7 @@ internal class StreamingApiRepositoryTest {
                             productId.toInt(),
                             productQuality,
                             playbackMode,
+                            false,
                             "streamingSessionId",
                         ),
                     )

--- a/player/src/androidTest/kotlin/com/tidal/sdk/player/playlog/PlayLogTest.kt
+++ b/player/src/androidTest/kotlin/com/tidal/sdk/player/playlog/PlayLogTest.kt
@@ -169,7 +169,7 @@ class PlayLogTest {
 
     private fun loadAndPlayUntilEnd(mediaProduct: MediaProduct) = runTest {
         responseDispatcher[
-            "https://api.tidal.com/v1/tracks/1/playbackinfo?playbackmode=STREAM&assetpresentation=FULL&audioquality=LOW".toHttpUrl(),
+            "https://api.tidal.com/v1/tracks/1/playbackinfo?playbackmode=STREAM&assetpresentation=FULL&audioquality=LOW&immersiveaudio=true".toHttpUrl(),
         ] = {
             MockResponse().setBodyFromFile(
                 "api-responses/playbackinfo/tracks/playlogtest/get_1_bts.json"
@@ -228,7 +228,7 @@ class PlayLogTest {
     private fun loadAndPlayThenPauseThenPlay(mediaProduct: MediaProduct) = runTest {
         val gson = Gson()
         responseDispatcher[
-            "https://api.tidal.com/v1/tracks/1/playbackinfo?playbackmode=STREAM&assetpresentation=FULL&audioquality=LOW".toHttpUrl(),
+            "https://api.tidal.com/v1/tracks/1/playbackinfo?playbackmode=STREAM&assetpresentation=FULL&audioquality=LOW&immersiveaudio=true".toHttpUrl(),
         ] = {
             MockResponse().setBodyFromFile(
                 "api-responses/playbackinfo/tracks/playlogtest/get_1_bts.json",

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApi.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApi.kt
@@ -19,14 +19,17 @@ interface StreamingApi {
      * @param[trackId] The requested track id as [Int].
      * @param[audioQuality] The requested audio quality as [AudioQuality].
      * @param[playbackMode] The requested playback mode as [PlaybackMode].
+     * @param[immersiveAudio] The requested option to include immersive audio or not.
      * @param[streamingSessionId] The streaming session uuid as [String], created by the client,
      * for this streaming session.
      * @param[playlistUuid] The playlistUuid this play originates from as [String]. May be null.
      */
+    @Suppress("LongParameterList")
     suspend fun getTrackPlaybackInfo(
         trackId: Int,
         audioQuality: AudioQuality,
         playbackMode: PlaybackMode,
+        immersiveAudio: Boolean,
         streamingSessionId: String,
         playlistUuid: String? = null,
     ): PlaybackInfo

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefault.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefault.kt
@@ -23,12 +23,14 @@ internal class StreamingApiDefault(
         trackId: Int,
         audioQuality: AudioQuality,
         playbackMode: PlaybackMode,
+        immersiveAudio: Boolean,
         streamingSessionId: String,
         playlistUuid: String?,
     ) = playbackInfoRepository.getTrackPlaybackInfo(
         trackId,
         audioQuality,
         playbackMode,
+        immersiveAudio,
         streamingSessionId,
         playlistUuid,
     )

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/api/PlaybackInfoService.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/api/PlaybackInfoService.kt
@@ -34,6 +34,7 @@ internal interface PlaybackInfoService {
         @Query("playbackmode") playbackMode: PlaybackMode,
         @Query("assetpresentation") assetPresentation: AssetPresentation,
         @Query("audioquality") audioQuality: AudioQuality,
+        @Query("immersiveaudio") immersiveAudio: Boolean,
         @Header("x-tidal-streamingsessionid") streamingSessionId: String,
         @Header("x-tidal-playlistuuid") playlistUuid: String?,
     ): PlaybackInfo.Track

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepository.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepository.kt
@@ -16,6 +16,7 @@ internal interface PlaybackInfoRepository {
      * @param[trackId] The requested track id as [Int].
      * @param[audioQuality] The requested audio quality as [AudioQuality].
      * @param[playbackMode] The requested playback mode as [PlaybackMode].
+     * @param[immersiveAudio] The requested option to include immersive audio or not.
      * @param[streamingSessionId] The streaming session uuid as [String], created by the client,
      * for this streaming session.
      * @param[playlistUuid] The playlistUuid this play originates from as [String]. May be null.
@@ -24,6 +25,7 @@ internal interface PlaybackInfoRepository {
         trackId: Int,
         audioQuality: AudioQuality,
         playbackMode: PlaybackMode,
+        immersiveAudio: Boolean,
         streamingSessionId: String,
         playlistUuid: String?,
     ): PlaybackInfo

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefault.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefault.kt
@@ -31,6 +31,7 @@ internal class PlaybackInfoRepositoryDefault(
         trackId: Int,
         audioQuality: AudioQuality,
         playbackMode: PlaybackMode,
+        immersiveAudio: Boolean,
         streamingSessionId: String,
         playlistUuid: String?,
     ) = try {
@@ -39,6 +40,7 @@ internal class PlaybackInfoRepositoryDefault(
             playbackMode,
             AssetPresentation.FULL,
             audioQuality,
+            immersiveAudio,
             streamingSessionId,
             playlistUuid,
         )

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
@@ -155,6 +155,7 @@ internal class StreamingApiDefaultTest {
             ApiConstants.PLAYBACK_INFO_ID_FOR_DEFAULT,
             AudioQuality.LOW,
             PlaybackMode.STREAM,
+            true,
             "streamingSessionId",
             null,
         )

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/api/PlaybackInfoServiceStub.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/api/PlaybackInfoServiceStub.kt
@@ -23,6 +23,7 @@ internal class PlaybackInfoServiceStub : PlaybackInfoService {
         playbackMode: PlaybackMode,
         assetPresentation: AssetPresentation,
         audioQuality: AudioQuality,
+        immersiveAudio: Boolean,
         streamingSessionId: String,
         playlistUuid: String?,
     ) = when (trackId) {

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/api/PlaybackInfoServiceTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/api/PlaybackInfoServiceTest.kt
@@ -158,6 +158,7 @@ internal class PlaybackInfoServiceTest {
             PlaybackMode.STREAM,
             AssetPresentation.FULL,
             AudioQuality.LOW,
+            true,
             ApiConstants.STREAMING_SESSION_ID,
             null,
         )

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefaultTest.kt
@@ -58,6 +58,7 @@ internal class PlaybackInfoRepositoryDefaultTest {
             trackId,
             AudioQuality.LOW,
             PlaybackMode.STREAM,
+            true,
             "streamingSessionId",
             null,
         )


### PR DESCRIPTION
The `playbackinfo` endpoint now supports a new boolean parameter called `immersiveaudio`. When set to false, backend will return a stereo version of the requested track if it's an immersive audio track.

In this PR, we add support for the new parameter as well as having this setting under the playback controls in the test app to easily test this.

![Screenshot_20240530_231954](https://github.com/tidal-music/tidal-sdk-android/assets/9930947/9d2a3c28-1bd1-4df7-8a8d-9819792f381f)
