### PR TITLE
Small improvements to auth test app setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This is the repository for TIDAL Android SDK modules.
 
 ### First time setup
 It is strongly recommended to run `local-setup.sh` right after cloning the repository. This will install the pre-commit git hook to run lint checks for your code. CI will also run these checks, but it's best to prevent CI failures by running the checks locally.
+To run a specific module's test app, you might have to create a `local.properties` file in the root of the project, and add values according to that app's requirements.
+``
 ### Creating a new module
 1. Run the `generate-module.sh` script. It will prompt you to enter a module name using [PascalCase](https://pl.wikipedia.org/wiki/PascalCase).
 After confirming the name, a new directory will be created with the basic module setup.

--- a/auth/apps/demo/build.gradle.kts
+++ b/auth/apps/demo/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.tidal.sdk.plugins.extensions.loadLocalProperties
+
 plugins {
     alias(libs.plugins.tidal.android.application)
 }
@@ -12,6 +14,13 @@ android {
     }
 
     buildTypes {
+        all {
+            buildConfigField(
+                "String",
+                "TIDAL_CLIENT_SCOPES",
+                "${project.loadLocalProperties()["tidal.clientscopes"]}",
+            )
+        }
         debug {}
         composeOptions {
             kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()

--- a/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
+++ b/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
@@ -48,8 +48,14 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        /**
+         * This test app expects the following values in 'local.properties' to be set:
+         * TIDAL_CLIENT_ID: The id of the app created by you in the TIDAL developer portal
+         * TIDAL_CLIENT_SECRET: The secret generated for this id
+         * TIDAL_CLIENT_SCOPES: The scopes you selected in the portal, entered as a single
+         * string, scopes separated by a space
+         */
         val authConfig = AuthConfig(
-            // Make sure to provide your clientId and required credentials in local.properties
             clientId = BuildConfig.TIDAL_CLIENT_ID,
             clientSecret = BuildConfig.TIDAL_CLIENT_SECRET,
             scopes = BuildConfig.TIDAL_CLIENT_SCOPES.split(" ").toSet(),

--- a/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
+++ b/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
@@ -52,8 +52,8 @@ class MainActivity : ComponentActivity() {
             // Make sure to provide your clientId and required credentials in local.properties
             clientId = BuildConfig.TIDAL_CLIENT_ID,
             clientSecret = BuildConfig.TIDAL_CLIENT_SECRET,
+            scopes = BuildConfig.TIDAL_CLIENT_SCOPES.split(" ").toSet(),
             credentialsKey = STORAGE_KEY,
-            scopes = setOf("YOUR_SCOPES"),
             enableCertificatePinning = true,
             logLevel = NetworkLogLevel.BODY,
         )

--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidApplicationConventionPlugin.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidApplicationConventionPlugin.kt
@@ -3,8 +3,8 @@ package com.tidal.sdk.plugins
 import com.tidal.sdk.plugins.constant.Config
 import com.tidal.sdk.plugins.constant.PluginId
 import com.tidal.sdk.plugins.extensions.androidApplication
-import java.io.File
-import java.util.Properties
+import com.tidal.sdk.plugins.extensions.loadLocalProperties
+import com.tidal.sdk.plugins.extensions.localPropertiesFile
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
@@ -28,11 +28,7 @@ internal class KotlinAndroidApplicationConventionPlugin : Plugin<Project> {
     }
 
     private fun Project.configureApplication() {
-        val localProperties = Properties()
-        val localPropertiesFile: File = rootProject.file("local.properties")
-        if (localPropertiesFile.exists()) {
-            localProperties.load(localPropertiesFile.inputStream())
-        }
+        val localProperties = loadLocalProperties()
 
         val tidalClientId = "tidal.clientid"
         val clientId = localProperties[tidalClientId]

--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/extensions/GradleAPIExtensions.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/extensions/GradleAPIExtensions.kt
@@ -2,6 +2,8 @@ package com.tidal.sdk.plugins.extensions
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.LibraryExtension
+import java.io.File
+import java.util.Properties
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
 
@@ -28,3 +30,25 @@ internal fun Project.androidApplication(action: ApplicationExtension.() -> Unit)
 internal fun Project.androidLibrary(action: LibraryExtension.() -> Unit) {
     action.invoke(extensions.getByType())
 }
+
+/**
+ * Extension function that loads properties from a 'local.properties' file
+ * 'local.properties' is expected to be in the project root.
+ */
+fun Project.loadLocalProperties(): Properties {
+    val properties = Properties()
+    with(localPropertiesFile) {
+        if (exists()) {
+            properties.load(inputStream())
+        } else {
+            logger.warn("Attempted to read 'local.properties' but file was not found!")
+        }
+    }
+    return properties
+}
+
+/**
+ * Extension property that returns the 'local.properties' file
+ * 'local.properties' is expected to be in the project root.
+ */
+val Project.localPropertiesFile: File get() = rootProject.file("local.properties")


### PR DESCRIPTION
Now scopes are also read from `local.properties`.

Additionally, I've made `KotlinAndroidApplicationConventionPlugin` a bit more flexible by moving the handling of `local.properties` into extensions functions. This way it is easy for modules to define their own properties without interfering with the plugin, and without needless code duplication.

Also added a few documentary lines to help devs get onboarded with this.