### PR TITLE
Making StreamingPrivilegesRevoked payload and clientDisplayName nullable

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
@@ -358,7 +358,7 @@ internal class ExoPlayerPlaybackEngine(
         }
     }
 
-    override fun onStreamingPrivilegesRevoked(privilegedClientDisplayName: String) {
+    override fun onStreamingPrivilegesRevoked(privilegedClientDisplayName: String?) {
         if (playbackState == PlaybackState.PLAYING) {
             coroutineScope.launch {
                 eventSink.emit(Event.StreamingPrivilegesRevoked(privilegedClientDisplayName))

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/model/Event.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/model/Event.kt
@@ -45,7 +45,7 @@ sealed interface Event {
      * streaming privilege loss for this instance.
      */
     data class StreamingPrivilegesRevoked internal constructor(
-        val privilegedClientDisplayName: String,
+        val privilegedClientDisplayName: String?,
     ) : Event
 
     /**

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesEventDispatcher.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesEventDispatcher.kt
@@ -18,7 +18,7 @@ internal class StreamingPrivilegesEventDispatcher(private val networkInteraction
 
     fun dispatchStreamingPrivilegeRevoked(
         connectionMutableState: ConnectionMutableState,
-        privilegedClientDisplayName: String,
+        privilegedClientDisplayName: String?,
     ) {
         networkInteractionsHandler.post {
             connectionMutableState.streamingPrivilegesListener

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesListener.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesListener.kt
@@ -20,5 +20,5 @@ interface StreamingPrivilegesListener {
      * @param privilegedClientDisplayName A name representative of the client that has caused this
      * client to lose streaming privileges.
      */
-    fun onStreamingPrivilegesRevoked(privilegedClientDisplayName: String)
+    fun onStreamingPrivilegesRevoked(privilegedClientDisplayName: String?)
 }

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/messages/WebSocketMessage.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/messages/WebSocketMessage.kt
@@ -10,7 +10,7 @@ internal sealed interface WebSocketMessage {
 
         object Reconnect : Incoming
 
-        data class StreamingPrivilegesRevoked(val privilegedClientDisplayName: String) : Incoming
+        data class StreamingPrivilegesRevoked(val privilegedClientDisplayName: String?) : Incoming
 
         enum class Type(val string: String) {
 

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/messages/incoming/IncomingWebSocketMessageParser.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/messages/incoming/IncomingWebSocketMessageParser.kt
@@ -14,9 +14,9 @@ internal class IncomingWebSocketMessageParser(private val gson: Gson) {
                     WebSocketMessage.Incoming.Reconnect
 
                 WebSocketMessage.Incoming.Type.STREAMING_PRIVILEGES_REVOKED.string -> {
-                    val payload = parsedMessage["payload"].asJsonObject
+                    val payload = parsedMessage["payload"]?.asJsonObject
                     WebSocketMessage.Incoming.StreamingPrivilegesRevoked(
-                        payload["clientDisplayName"].asString,
+                        payload?.get("clientDisplayName")?.asString
                     )
                 }
 


### PR DESCRIPTION
When streaming privileges are revoked, both the `payload` and `clientDisplayName` can be null. Backend cannot guarantee returning them. We need to treat them as such. The clients would need to handle displaying the appropriate generic message in case the `clientDisplayName` is `null`.