### PR TITLE
Fix concurrency management within getCredentials

### DIFF
--- a/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
@@ -70,6 +70,11 @@ internal class TokenRepository(
         getCredentialsCalls.incrementAndGet()
         logger.d { "Received subStatus: $apiErrorSubStatus" }
         val latestTokens = getLatestTokens()
+        /**
+         * Note the double if check. This is to avoid synchronized whenever possible (since it's
+         * slow). It's the same reason why when you write a singleton you're supposed to do the
+         * null check both outside and inside the synchronized call.
+         */
         if ((latestTokens?.credentials?.isExpired(timeProvider) != false) ||
             needsCredentialsUpgrade()
         ) {

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/storage/DefaultTokensStore.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/storage/DefaultTokensStore.kt
@@ -5,16 +5,18 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import com.tidal.sdk.auth.model.Tokens
 import com.tidal.sdk.common.logger
 import com.tidal.sdk.common.w
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.serialization.decodeFromString as decode
 import kotlinx.serialization.encodeToString as encode
-import kotlinx.serialization.json.Json
 
 /**
  * This class uses [EncryptedSharedPreferences] to securely store credentials.
  * Pass in a [SharedPreferences] instance to use a custom one, by default
  * we inject an [EncryptedSharedPreferences] instance.
  */
+@Singleton
 internal class DefaultTokensStore @Inject constructor(
     private val credentialsKey: String,
     private val sharedPreferences: SharedPreferences,


### PR DESCRIPTION
This ensures that only the refreshes/upgrades that need to happen actually happen.

In addition, I've reworked the log calls to be more accurate when it comes to matching what actually happens.