### PR TITLE
Set instrumented test CI job timeout to 60 minutes

### DIFF
--- a/.github/workflows/instrumented-test.yml
+++ b/.github/workflows/instrumented-test.yml
@@ -10,6 +10,7 @@ jobs:
   run-instrumented-tests:
     runs-on: ubuntu-latest
     name: Run instrumented tests
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Enable KVM group perms


### PR DESCRIPTION
This helps us fail earlier and cost less money when the UI test job gets stuck.