### PR TITLE
Use google_apis target

### DIFF
--- a/.github/workflows/instrumented-test.yml
+++ b/.github/workflows/instrumented-test.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           api-level: 29
           script: ./gradlew -Dorg.gradle.logging.level=quiet connectedCheck
+          target: google_apis


### PR DESCRIPTION
I'm getting quite frustrated by how often the UI test job hangs so I'm determined to solve it. I've found an issue on the action repo (linked in the commit message) which points out this as a reason so I'm gonna suggest that we give it a shot.