### PR TITLE
Run instrumented tests on x86_64 ABI-compatible host 

### DIFF
--- a/.github/workflows/instrumented-test.yml
+++ b/.github/workflows/instrumented-test.yml
@@ -26,4 +26,5 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2.30.1
         with:
           api-level: 29
+          arch: x86_64
           script: ./gradlew -Dorg.gradle.logging.level=quiet connectedCheck


### PR DESCRIPTION
The default was x86 for which we don't even have active device installs of the
main app in Google Play.

Not that we have any for x86_64 either, but it's "slightly closer of a step" to
arm64-8va given that ARM-based Actions runners aren't available yet.