### PR TITLE
Auto-cancel PR CI when pushing to the same branch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trigger-lint:
     name: Trigger linters


### PR DESCRIPTION
This will reduce active runners on CI when making corrections, lowering costs and hopefully increasing stability and wall times due to machine availability.

Tangentially related to the UI test job getting stuck as I have noticed that it seems to do so less often when there are less other jobs running, so I would like to see if this helps it before considering the extreme of allowing only one UI test job to be running at a time.