### PR TITLE
Rework MediaProductTransition to be emitted on load

### DIFF
--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivity.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivity.kt
@@ -65,7 +65,7 @@ internal class MainActivity : ComponentActivity() {
                                         addedNonTopPadding,
                                 ),
                                 dispatchLoad = {
-                                    dispatch(Impure.Load(it))
+                                    dispatch(MainActivityViewModel.Operation.Pure.Load(it))
                                 },
                                 dispatchSetNext = {
                                     dispatch(Impure.SetNext(it))

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModel.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModel.kt
@@ -132,6 +132,13 @@ internal class MainActivityViewModel(context: Context) : ViewModel() {
 
             abstract suspend fun invokePure(state: T)
 
+            class Load(private val mediaProduct: MediaProduct) : Pure<PlayerInitialized>() {
+
+                override suspend fun invokePure(state: PlayerInitialized) {
+                    state.player.playbackEngine.load(mediaProduct)
+                }
+            }
+
             sealed class Seek : Pure<PlayerInitialized>() {
 
                 override suspend fun invokePure(state: PlayerInitialized) {
@@ -283,15 +290,6 @@ internal class MainActivityViewModel(context: Context) : ViewModel() {
                 companion object {
                     private const val CACHE_DIR = "exoplayer-cache"
                     private val CACHE_MAX_SIZE_BYTES = 50.megabytes.value
-                }
-            }
-
-            class Load(private val mediaProduct: MediaProduct) :
-                Impure<PlayerInitialized, PlayerInitialized>() {
-
-                override suspend operator fun invoke(state: PlayerInitialized): PlayerInitialized {
-                    state.player.playbackEngine.load(mediaProduct)
-                    return state.copy(current = mediaProduct)
                 }
             }
 

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngineTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngineTest.kt
@@ -719,7 +719,7 @@ internal class ExoPlayerPlaybackEngineTest {
 
         assertThat(playbackEngine.reflectionCurrentPlaybackStatistics).isSameAs(playbackStatistics)
         verify(currentMediaSource, atLeastOnce()).forwardingMediaProduct
-        verify(currentForwardingMediaProduct).delegate
+        verify(currentForwardingMediaProduct, atLeastOnce()).delegate
         verify(currentMediaProduct).referenceId
         verify(playbackContextFactory).create(playbackInfo, referenceId)
         assertThat(playbackEngine.playbackContext).isEqualTo(playbackContext)


### PR DESCRIPTION
This makes MediaProductTransition align better to the spec by representing a change on the MediaProduct property instead of on the last MediaProduct to have received a command.