### PR TITLE
Remove kotlinx.datetime from auth module

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(libs.kotlinxCoroutinesAndroid)
     implementation(libs.kotlinxCoroutinesCore)
     implementation(libs.kotlinx.coroutines.test)
-    api(libs.kotlinx.datetime)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.retrofit.converter)
     implementation(libs.okhttp.loggingInterceptor)

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
@@ -132,7 +132,7 @@ internal class TokenRepository(
             val token = Credentials.create(
                 authConfig,
                 timeProvider,
-                expiresIn = it.expiresIn,
+                expiresIn = it.expiresIn ?: 0,
                 userId = it.userId.toString(),
                 token = it.accessToken,
             )

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/login/LoginRepository.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/login/LoginRepository.kt
@@ -20,7 +20,6 @@ import com.tidal.sdk.common.TidalMessage
 import com.tidal.sdk.common.d
 import com.tidal.sdk.common.logger
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.datetime.Instant
 
 internal class LoginRepository constructor(
     private val authConfig: AuthConfig,
@@ -98,9 +97,7 @@ internal class LoginRepository constructor(
                 authConfig.clientUniqueKey,
                 response.scopesString.split(", ").toSet(),
                 response.userId?.toString(),
-                Instant.fromEpochSeconds(
-                    timeProvider.now.epochSeconds + response.expiresIn.toLong(),
-                ),
+                timeProvider.now + response.expiresIn.toLong(),
                 response.accessToken,
             ),
             refreshToken = response.refreshToken,

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/model/RefreshResponse.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/model/RefreshResponse.kt
@@ -9,7 +9,7 @@ internal data class RefreshResponse(
     val accessToken: String,
     val clientName: String? = null,
     @JsonNames("expires_in")
-    val expiresIn: Int,
+    val expiresIn: Long,
     @JsonNames("token_type")
     val tokenType: String,
     @JsonNames("scope")

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/model/UpgradeResponse.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/model/UpgradeResponse.kt
@@ -12,7 +12,7 @@ internal data class UpgradeResponse(
     @JsonNames("token_type")
     val tokenType: String?,
     @JsonNames("expires_in")
-    val expiresIn: Int? = 0,
+    val expiresIn: Long? = 0,
     @JsonNames("user_id")
     val userId: Int? = null,
 )

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/storage/LegacyCredentials.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/storage/LegacyCredentials.kt
@@ -1,7 +1,6 @@
 package com.tidal.sdk.auth.storage
 
 import com.tidal.sdk.auth.model.Credentials
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 /**
@@ -15,7 +14,7 @@ internal data class LegacyCredentials(
     val clientUniqueKey: String?,
     val grantedScopes: Scopes,
     val userId: String?,
-    val expires: Instant?,
+    val expires: Long?,
     val token: String?,
 ) {
     fun toCredentials(): Credentials {

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/util/DefaultTimeProvider.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/util/DefaultTimeProvider.kt
@@ -1,9 +1,6 @@
 package com.tidal.sdk.auth.util
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-
 internal class DefaultTimeProvider : TimeProvider {
-    override val now: Instant
-        get() = Clock.System.now()
+    override val now: Long
+        get() = System.currentTimeMillis() / 1000
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/util/DefaultTimeProvider.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/util/DefaultTimeProvider.kt
@@ -2,5 +2,5 @@ package com.tidal.sdk.auth.util
 
 internal class DefaultTimeProvider : TimeProvider {
     override val now: Long
-        get() = System.currentTimeMillis() / 1000
+        get() = currentTimeSeconds()
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/util/TimeProvider.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/util/TimeProvider.kt
@@ -1,7 +1,5 @@
 package com.tidal.sdk.auth.util
 
-import kotlinx.datetime.Instant
-
 internal interface TimeProvider {
-    val now: Instant
+    val now: Long
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/util/Utils.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/util/Utils.kt
@@ -70,3 +70,12 @@ internal suspend fun <T> retryWithPolicyUnwrapped(
     }
     throw (throwable!!)
 }
+
+/**
+ * Convenience function get the current time in seconds.
+ */
+internal fun currentTimeSeconds(): Long {
+    return System.currentTimeMillis() / MILLISECONDS
+}
+
+private const val MILLISECONDS = 1000

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/FakeLoginService.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/FakeLoginService.kt
@@ -128,7 +128,7 @@ internal class FakeLoginService(
         private val startTime = timeProvider.now
 
         fun isPending(): Boolean {
-            return startTime.epochSeconds + pendingForSeconds > timeProvider.now.epochSeconds
+            return startTime + pendingForSeconds > timeProvider.now
         }
     }
 }

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/model/CredentialsTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/model/CredentialsTest.kt
@@ -1,9 +1,6 @@
 package com.tidal.sdk.auth.model
 
 import com.tidal.sdk.util.TestTimeProvider
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
-import kotlinx.datetime.Clock.System.now
 import org.junit.jupiter.api.Test
 
 class CredentialsTest {
@@ -13,8 +10,8 @@ class CredentialsTest {
     @Test
     fun `An access token expiring in more than a minute is valid`() {
         // given
-        val time = now()
-        val expiry = time.plus(2.toDuration(DurationUnit.MINUTES))
+        val time = System.currentTimeMillis() / 1000
+        val expiry = time + 120
         val token = Credentials(
             "",
             setOf(),
@@ -37,8 +34,8 @@ class CredentialsTest {
     @Test
     fun `An access token expiring in less than a minute is not valid`() {
         // given
-        val time = now()
-        val expiry = time.plus(30.toDuration(DurationUnit.SECONDS))
+        val time = System.currentTimeMillis() / 1000
+        val expiry = time + 30
         val token = Credentials(
             "",
             setOf(),

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/model/CredentialsTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/model/CredentialsTest.kt
@@ -1,5 +1,6 @@
 package com.tidal.sdk.auth.model
 
+import com.tidal.sdk.auth.util.currentTimeSeconds
 import com.tidal.sdk.util.TestTimeProvider
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,7 @@ class CredentialsTest {
     @Test
     fun `An access token expiring in more than a minute is valid`() {
         // given
-        val time = System.currentTimeMillis() / 1000
+        val time = currentTimeSeconds()
         val expiry = time + 120
         val token = Credentials(
             "",
@@ -34,7 +35,7 @@ class CredentialsTest {
     @Test
     fun `An access token expiring in less than a minute is not valid`() {
         // given
-        val time = System.currentTimeMillis() / 1000
+        val time = currentTimeSeconds()
         val expiry = time + 30
         val token = Credentials(
             "",

--- a/auth/src/test/kotlin/com/tidal/sdk/util/CoroutineTestTimeProvider.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/util/CoroutineTestTimeProvider.kt
@@ -5,11 +5,11 @@ import com.tidal.sdk.util.CoroutineTestTimeProvider.Mode
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.datetime.Instant
 
 /**
  * [TimeProvider] implementation that can be used to control time flow inside a
@@ -27,13 +27,12 @@ class CoroutineTestTimeProvider(
 ) : TimeProvider {
 
     override val now
-        get() = Instant.fromEpochMilliseconds(getTime())
+        get() = getTimeSeconds()
 
     private var timeJob: Job? = null
 
-    private fun getTime(): Long {
-        return dispatcher.scheduler.currentTime
-    }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun getTimeSeconds(): Long = (dispatcher.scheduler.currentTime) / 1000
 
     fun startTimeFor(scope: CoroutineScope, units: Int) {
         if (mode == Mode.SECONDS) {

--- a/auth/src/test/kotlin/com/tidal/sdk/util/TestTimeProvider.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/util/TestTimeProvider.kt
@@ -13,7 +13,7 @@ class TestTimeProvider : TimeProvider {
     }
 
     override val now
-        get() = clock.now()
+        get() = clock.now().epochSeconds
 
     fun advanceSeconds(seconds: Int) =
         clock.advance(seconds.toDuration(DurationUnit.SECONDS)).also {

--- a/auth/src/test/kotlin/com/tidal/sdk/util/TestUtils.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/util/TestUtils.kt
@@ -19,9 +19,9 @@ fun makeCredentials(
     token: String = "token",
 ): Credentials {
     val expiry = if (isExpired) {
-        TEST_TIME_PROVIDER.now.minus(5.toDuration(DurationUnit.MINUTES))
+        TEST_TIME_PROVIDER.now.minus(5.toDuration(DurationUnit.MINUTES).inWholeSeconds)
     } else {
-        TEST_TIME_PROVIDER.now.plus(5.toDuration(DurationUnit.MINUTES))
+        TEST_TIME_PROVIDER.now.plus(5.toDuration(DurationUnit.MINUTES).inWholeSeconds)
     }
     return Credentials(
         clientId = clientId,

--- a/eventproducer/build.gradle.kts
+++ b/eventproducer/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     implementation(libs.dagger)
     implementation(libs.kotlinxCoroutinesCore)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.retrofit)
     implementation(libs.room.runtime)
     implementation(libs.moshi)

--- a/eventproducer/src/test/kotlin/com/tidal/eventproducer/fakes/FakeCredentialsProvider.kt
+++ b/eventproducer/src/test/kotlin/com/tidal/eventproducer/fakes/FakeCredentialsProvider.kt
@@ -7,6 +7,7 @@ import com.tidal.sdk.common.NetworkError
 import com.tidal.sdk.common.TidalMessage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Instant
 
 class FakeCredentialsProvider(
     private val isSuccessResult: Boolean = true,

--- a/eventproducer/src/test/kotlin/com/tidal/eventproducer/fakes/FakeCredentialsProvider.kt
+++ b/eventproducer/src/test/kotlin/com/tidal/eventproducer/fakes/FakeCredentialsProvider.kt
@@ -7,7 +7,6 @@ import com.tidal.sdk.common.NetworkError
 import com.tidal.sdk.common.TidalMessage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.datetime.Instant
 
 class FakeCredentialsProvider(
     private val isSuccessResult: Boolean = true,


### PR DESCRIPTION
`kotlinx.datetime` uses Java APIs under the hood that aren't available on Android SDK versions 25 and below.
To not make SDK users jump through some extra hoops to get this module up and running, this PR removes its usage.

Instead, we now just use Unix Epoch seconds. The only use of time measuring inside auth is to calculate when nearing a token's expiry date, so we actually don't need much sophistication here. 

This has been tested to work on API 24