### PR TITLE
Bump auth version to 0.10.0

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.2] - 2024-07-03
+## [0.10.0] - 2024-07-16
 ### Changed
+- Dependency on kotlinx.datetime removed - this makes auth compatible to Android SDK <26
+- Because of this change, `Credentials` type's `expires` is now a `Long`. 
+
+## [0.9.2] - 2024-07-03
+### Fixed
 - Fix bug preventing properly synchronized backend calls when requesting a new token
 
 ## [0.9.1] - 2024-05-28

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Auth module manages app authentication, authorization, and token handling, simplifying OAuth processes, ensuring secure user access, and offering robust error handling.
-version=0.9.2
+version=0.10.0


### PR DESCRIPTION
Since we're changing the signature of `Credentials` as a result of removing the `kotlinx.datetime` dependency, this is bumped to the next minor version.

Once this version is released, an update to `libs.versions.toml` will follow, together with the potentially necessary changes to other modules.