### PR TITLE
Update SDK lib versions in libs.versions.toml

### DIFF
--- a/eventproducer/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
+++ b/eventproducer/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.datetime.Instant
 
 class MainActivity : ComponentActivity() {
 
@@ -49,7 +48,7 @@ class MainActivity : ComponentActivity() {
             clientUniqueKey = "clientUniqueKey",
             grantedScopes = emptySet(),
             userId = "123",
-            expires = Instant.DISTANT_FUTURE,
+            expires = Long.MAX_VALUE,
             token = null,
         )
         return object : CredentialsProvider {

--- a/eventproducer/build.gradle.kts
+++ b/eventproducer/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
 
     implementation(libs.dagger)
     implementation(libs.kotlinxCoroutinesCore)
-    implementation(libs.kotlinx.datetime)
     implementation(libs.retrofit)
     implementation(libs.room.runtime)
     implementation(libs.moshi)

--- a/eventproducer/src/test/kotlin/com/tidal/eventproducer/fakes/FakeCredentialsProvider.kt
+++ b/eventproducer/src/test/kotlin/com/tidal/eventproducer/fakes/FakeCredentialsProvider.kt
@@ -7,7 +7,6 @@ import com.tidal.sdk.common.NetworkError
 import com.tidal.sdk.common.TidalMessage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.datetime.Instant
 
 class FakeCredentialsProvider(
     private val isSuccessResult: Boolean = true,
@@ -23,14 +22,12 @@ class FakeCredentialsProvider(
 
     override suspend fun getCredentials(
         apiErrorSubStatus: String?,
-    ): AuthResult<Credentials> {
-        return if (isSuccessResult) {
-            accessToken = refreshToken
-            clientId = refreshClientId
-            AuthResult.Success(getDefaultCredentials(accessToken, clientId))
-        } else {
-            AuthResult.Failure(NetworkError("404"))
-        }
+    ): AuthResult<Credentials> = if (isSuccessResult) {
+        accessToken = refreshToken
+        clientId = refreshClientId
+        AuthResult.Success(getDefaultCredentials(accessToken, clientId))
+    } else {
+        AuthResult.Failure(NetworkError("404"))
     }
 
     override fun isUserLoggedIn() = true
@@ -41,7 +38,7 @@ class FakeCredentialsProvider(
         clientUniqueKey = "",
         grantedScopes = emptySet(),
         userId = "",
-        expires = Instant.DISTANT_FUTURE,
+        expires = Long.MAX_VALUE,
         token = accessToken,
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,9 +81,9 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-retrofit-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version = "1.0.0" }
 
 # SDK
-tidal-sdk-catalogue = { module = "com.tidal.sdk:catalogue", version = "0.1.0" }
+tidal-sdk-catalogue = { module = "com.tidal.sdk:catalogue", version = "0.1.1-alpha" }
 tidal-sdk-common = { module = "com.tidal.sdk:common", version = "0.2.5" }
-tidal-sdk-auth = { module = "com.tidal.sdk:auth", version = "0.9.1" }
+tidal-sdk-auth = { module = "com.tidal.sdk:auth", version = "0.10.1" }
 tidal-sdk-eventproducer = { module = "com.tidal.sdk:eventproducer", version = "0.3.2" }
 tidal-sdk-player = { module = "com.tidal.sdk:player", version = "0.0.39" }
 


### PR DESCRIPTION
catalogue is now 0.1.1-alpha and auth is 0.10.1.

Eventproducer has been updated with the necessary (tiny) changes to make it work with auth 0.10.1
Other than that, nothing to see here