### PR TITLE
Fix race condition for playbackInfo

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadable.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadable.kt
@@ -44,7 +44,7 @@ internal class PlaybackInfoLoadable(
         try {
             coroutineScopeF().also {
                 coroutineScope = it
-                playbackInfo = runBlocking(it.coroutineContext) {
+                runBlocking(it.coroutineContext) {
                     when (playbackPrivilegeProvider.get(forwardingMediaProduct.delegate)) {
                         PlaybackPrivilege.OK_ONLINE ->
                             streamingApiRepository.getPlaybackInfoForStreaming(
@@ -60,6 +60,7 @@ internal class PlaybackInfoLoadable(
 
                         PlaybackPrivilege.OFFLINE_EXPIRED -> throw OfflineExpiredException()
                     }.also {
+                        playbackInfo = it
                         extendedExoPlayerState.playbackInfoListener?.onPlaybackInfoFetched(
                             streamingSession,
                             forwardingMediaProduct,


### PR DESCRIPTION
Currently we have a volume issue where volume is wrongly set causing some tracks to be very loud. After investigating it, it seems that `volumeHelper.getVolume(mediaSource?.playbackInfo)` is returning `FULL_VOLUME` in some cases because `playbackInfo` is `null`.

The reason `playbackInfo` is `null` in this case is because sometimes `onPlaybackInfoFetched` is being called before `playbackInfo` is actually set. And `onPlaybackInfoFetched` calls `updatePlayerVolume` which then results in the wrong volume. The issue does not happen every time since it depends on the race condition. But it is frequent.

This PR at least makes sure that both `playbackInfo` and `onPlaybackInfoFetched` are both done in the same scope. Couldn't reproduce the issue after this fix.