### PR TITLE
Reset Playback Engine on PlaybackInfo fetch error

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
@@ -824,12 +824,17 @@ internal class ExoPlayerPlaybackEngine(
         }
 
         val eventError = errorHandler.getErrorEvent(error, forwardingMediaProduct?.productType)
+        coroutineScope.launch {
+            eventSink.emit(eventError)
+        }
         playbackInfoFetchException.report(errorMessage, eventError.errorCode)
         val matchingMediaProduct = eventTime.correspondingForwardingMediaProductIfMatching
         if (matchingMediaProduct === forwardingMediaProduct ||
             matchingMediaProduct === nextForwardingMediaProduct
         ) {
-            if (matchingMediaProduct === forwardingMediaProduct) {
+            if (playbackInfoFetchException != null) {
+                reset()
+            } else if (matchingMediaProduct === forwardingMediaProduct) {
                 val positionInSeconds =
                     if (forwardingMediaProduct?.productType == ProductType.BROADCAST) {
                         extendedExoPlayer.currentPositionSinceEpochMs
@@ -843,9 +848,6 @@ internal class ExoPlayerPlaybackEngine(
                     positionInSeconds,
                 )
             }
-        }
-        coroutineScope.launch {
-            eventSink.emit(eventError)
         }
     }
 


### PR DESCRIPTION
This can happen at two points:
* On load for the current item, which is when the PBI fetch error is raised as a player error.
* On playback start of the next item, which when the PBI fetch error is raised as a player error. While this delays the issue, it is good, because it allows playback of the current item to finish.