### PR TITLE
MF-169: Remove check for presence of client secret

### DIFF
--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidApplicationConventionPlugin.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidApplicationConventionPlugin.kt
@@ -33,6 +33,8 @@ internal class KotlinAndroidApplicationConventionPlugin : Plugin<Project> {
 
         val tidalClientId = "tidal.clientid"
         val clientId = localProperties[tidalClientId]
+        val tidalClientSecret = "tidal.clientsecret"
+        val clientSecret = localProperties[tidalClientSecret]
         val tidalClientRedirectUri = "tidal.clientredirecturi"
         val clientRedirectUri = localProperties[tidalClientRedirectUri]
         androidApplication {
@@ -49,7 +51,7 @@ internal class KotlinAndroidApplicationConventionPlugin : Plugin<Project> {
                 buildConfigField(
                     "String",
                     "TIDAL_CLIENT_SECRET",
-                    "${localProperties["tidal.clientsecret"]}",
+                    "$clientSecret",
                 )
                 buildConfigField(
                     "String",
@@ -84,6 +86,7 @@ internal class KotlinAndroidApplicationConventionPlugin : Plugin<Project> {
             doLast {
                 arrayOf(
                     tidalClientId to clientId,
+                    tidalClientSecret to clientSecret,
                     tidalClientRedirectUri to clientRedirectUri,
                 ).forEach { (key, value) ->
                     if (value == null && System.getenv("CI").isNullOrBlank()) {

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/LoginScreen.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/LoginScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.util.UnstableApi
-import com.tidal.sdk.player.BuildConfig
 import com.tidal.sdk.player.auth.weblogin.ComposeWebView
 
 @Composable
@@ -44,7 +43,7 @@ internal fun LoginScreen(
             dispatchSetSnackbarMessage(null)
         }
     }
-    if (state.isUserLoggedIn || !BuildConfig.TIDAL_CLIENT_SECRET.isNullOrBlank()) {
+    if (state.isUserLoggedIn) {
         LoadingScreen()
         val context = LocalContext.current
         LaunchedEffect(Unit) { dispatchFinalizeImplicitLoginFlow(context) }


### PR DESCRIPTION
It's been asked that we always perform a user login if isUserLoggedIn returns false, so we should no longer look at the presence of a client secret, which now becomes mandatory.