### PR TITLE
MF-168: Make redirect uri configurable

### DIFF
--- a/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/LoginScreen.kt
+++ b/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/LoginScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import com.tidal.sdk.demo.MainActivity.Companion.LOGIN_URI
+import com.tidal.sdk.auth.demo.BuildConfig
 import com.tidal.sdk.demo.webview.ComposeWebView
 
 @Composable
@@ -20,7 +20,7 @@ fun LoginScreen() {
         val context = LocalContext.current
         val activity = (context.findActivity() as MainActivity)
         return activity.auth.initializeLogin(
-            LOGIN_URI,
+            BuildConfig.TIDAL_CLIENT_REDIRECT_URI,
             activity.loginConfig,
         )
     }

--- a/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
+++ b/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/MainActivity.kt
@@ -134,7 +134,6 @@ class MainActivity : ComponentActivity() {
     companion object {
 
         private const val STORAGE_KEY = "storage"
-        const val LOGIN_URI = "https://tidal.com/android/login/auth"
     }
 }
 

--- a/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/webview/ExtendedWebClient.kt
+++ b/auth/apps/demo/src/main/kotlin/com/tidal/sdk/demo/webview/ExtendedWebClient.kt
@@ -7,7 +7,7 @@ import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import com.tidal.sdk.demo.MainActivity.Companion.LOGIN_URI
+import com.tidal.sdk.auth.demo.BuildConfig
 
 class ExtendedWebClient(
     private val onRedirectUriReceived: (Uri) -> Unit,
@@ -29,7 +29,7 @@ class ExtendedWebClient(
     }
 
     private fun hasRedirectUri(uri: Uri): Boolean {
-        return if (uri.toString().startsWith(LOGIN_URI)) {
+        return if (uri.toString().startsWith(BuildConfig.TIDAL_CLIENT_REDIRECT_URI)) {
             onRedirectUriReceived(uri)
             true
         } else {

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/auth/weblogin/ExtendedWebClient.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/auth/weblogin/ExtendedWebClient.kt
@@ -9,7 +9,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.media3.common.util.UnstableApi
-import com.tidal.sdk.player.mainactivity.MainActivityViewModel
+import com.tidal.sdk.player.BuildConfig
 
 @UnstableApi
 internal class ExtendedWebClient(
@@ -34,7 +34,7 @@ internal class ExtendedWebClient(
     }
 
     private fun hasRedirectUri(uri: Uri): Boolean {
-        return if (uri.toString().startsWith(MainActivityViewModel.LOGIN_URI)) {
+        return if (uri.toString().startsWith(BuildConfig.TIDAL_CLIENT_REDIRECT_URI)) {
             onRedirectUriReceived(context, uri)
             true
         } else {

--- a/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModel.kt
+++ b/player/apps/demo/src/main/kotlin/com/tidal/sdk/player/mainactivity/MainActivityViewModel.kt
@@ -66,7 +66,7 @@ internal class MainActivityViewModel(context: Context) : ViewModel() {
     }
     private val authLoginUri: Uri
         get() = tidalAuth.auth.initializeLogin(
-            LOGIN_URI,
+            BuildConfig.TIDAL_CLIENT_REDIRECT_URI,
             LoginConfig(
                 customParams = setOf(
                     QueryParameter(
@@ -543,10 +543,6 @@ internal class MainActivityViewModel(context: Context) : ViewModel() {
                         .copy()
             }
         }
-    }
-
-    companion object {
-        const val LOGIN_URI = "https://tidal.com/android/login/auth"
     }
 }
 


### PR DESCRIPTION
This allows working with clients whose redirect uri is not the same as that from the TIDAL app.