### PR TITLE
Consider InterruptedException as cancellations

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadable.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadable.kt
@@ -69,9 +69,11 @@ internal class PlaybackInfoLoadable(
                     }
                 }
             }
-        } catch (ignored: CancellationException) {
         } catch (throwable: Throwable) {
-            throw PlaybackInfoFetchException.Error(forwardingMediaProduct, throwable)
+            when (throwable) {
+                is CancellationException, is InterruptedException -> Unit
+                else -> throw PlaybackInfoFetchException.Error(forwardingMediaProduct, throwable)
+            }
         }
     }
 }


### PR DESCRIPTION
This can happen if you call load repeatedly too fast.

To reproduce, wrap the load call in a `repeat` statement

```kotlin
class Load(private val mediaProduct: MediaProduct) : Pure<PlayerInitialized>() {

    override suspend fun invokePure(state: PlayerInitialized) {
        repeat(100) {
            state.player.playbackEngine.load(mediaProduct.copy(productId = it.toString()))
        }
    }
}
```

And add some log calls in `PlaybackInfoLoadable` to understand what's happening:

```kotlin
} catch (throwable: Throwable) {
    when (throwable) {
        is CancellationException, is InterruptedException -> Unit.also {
            Log.d("HOLA", "Cancelled ${forwardingMediaProduct.productId}")
            return
        }
        else -> throw PlaybackInfoFetchException.Error(forwardingMediaProduct, throwable).also {
            Log.d("HOLA", "Errored ${forwardingMediaProduct.productId}", throwable)
        }
    }
}
Log.d("HOLA", "Succeeded ${forwardingMediaProduct.productId}")
```

You're going to see 100 loads, 99 cancellations and an error (due to the product id not being found, which is correct/intended).