### PR TITLE
Bump event producer version to 0.3.2

### DIFF
--- a/eventproducer/CHANGELOG.md
+++ b/eventproducer/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2024-08-20
+
+### Changed
+- Rely on TrueTime instead of the system clock in event headers 
+
 ## [0.3.1] - 2024-05-24
 
 ### Fixed

--- a/eventproducer/gradle.properties
+++ b/eventproducer/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Event Producer's responsibility is to transport submitted events as fast, secure and reliable as possible.
-version=0.3.1
+version=0.3.2


### PR DESCRIPTION
Creating new release since 0.3.1 doesn't include [this](https://github.com/tidal-music/tidal-sdk-android/pull/14) fix