### PR TITLE
Sort out auth token refresh and setCredentials synchronization

### DIFF
--- a/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
@@ -32,13 +32,9 @@ internal class TokenRepository(
     private val tokenService: TokenService,
     private val defaultBackoffPolicy: RetryPolicy,
     private val upgradeBackoffPolicy: RetryPolicy,
+    private val tokenMutex: Mutex,
     private val bus: MutableSharedFlow<TidalMessage>,
 ) {
-
-    /**
-     * Mutex to ensure that only one thread at a time can update/upgrade the token.
-     */
-    private val tokenMutex = Mutex()
 
     private fun needsCredentialsUpgrade(): Boolean {
         val storedCredentials = getLatestTokens()?.credentials

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/di/AuthComponent.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/di/AuthComponent.kt
@@ -6,6 +6,7 @@ import com.tidal.sdk.auth.model.AuthConfig
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
 
 @Singleton
 @Component(
@@ -27,6 +28,7 @@ interface AuthComponent {
         fun create(
             @BindsInstance context: Context,
             @BindsInstance config: AuthConfig,
+            @BindsInstance mutex: Mutex = Mutex(),
         ): AuthComponent
     }
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/di/CredentialsModule.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/di/CredentialsModule.kt
@@ -13,6 +13,7 @@ import dagger.Provides
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.sync.Mutex
 import retrofit2.Retrofit
 
 @Module
@@ -38,6 +39,7 @@ internal class CredentialsModule {
         tokenService: TokenService,
         @Named("default") defaultBackoffPolicy: RetryPolicy,
         @Named("upgrade") upgradeBackoffPolicy: RetryPolicy,
+        mutex: Mutex,
         bus: MutableSharedFlow<TidalMessage>,
     ) = TokenRepository(
         authConfig,
@@ -46,6 +48,7 @@ internal class CredentialsModule {
         tokenService,
         defaultBackoffPolicy,
         upgradeBackoffPolicy,
+        mutex,
         bus,
     )
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/di/LoginModule.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/di/LoginModule.kt
@@ -16,6 +16,7 @@ import dagger.Reusable
 import javax.inject.Named
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.sync.Mutex
 import retrofit2.Retrofit
 
 @Module
@@ -58,6 +59,7 @@ internal class LoginModule {
         loginUriBuilder: LoginUriBuilder,
         loginService: LoginService,
         tokensStore: TokensStore,
+        mutex: Mutex,
         @Named("default") retryPolicy: RetryPolicy,
         bus: MutableSharedFlow<TidalMessage>,
     ): LoginRepository = LoginRepository(
@@ -68,6 +70,7 @@ internal class LoginModule {
         loginService,
         tokensStore,
         retryPolicy,
+        mutex,
         bus,
     )
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/storage/legacycredentials/LegacyCredentialsMigrator.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/storage/legacycredentials/LegacyCredentialsMigrator.kt
@@ -24,12 +24,9 @@ internal class LegacyCredentialsMigrator {
         val exceptions = mutableListOf<Exception>()
         for (operation in operations) {
             try {
-                return operation().also {
-                    println("Successfully decoded using legacy types.")
-                }
+                return operation()
             } catch (e: Exception) {
                 logger.i { "Failed to decode using legacy types." }
-                println("Failed to decode using legacy types.")
                 exceptions.plus(e)
             }
         }

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/FakeTokenService.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/FakeTokenService.kt
@@ -9,6 +9,7 @@ internal class FakeTokenService : TokenService {
 
     var calls = mutableListOf<CallType>()
     var throwableToThrow: Throwable? = null
+    var responseDelay = 10L
 
     override suspend fun getTokenFromRefreshToken(
         clientId: String,
@@ -18,7 +19,7 @@ internal class FakeTokenService : TokenService {
         scope: String,
     ): RefreshResponse {
         calls.add(CallType.Refresh)
-        delay(10)
+        delay(responseDelay)
         throwableToThrow?.let {
             throw it
         } ?: run {
@@ -41,7 +42,7 @@ internal class FakeTokenService : TokenService {
         scope: String,
     ): RefreshResponse {
         calls.add(CallType.Secret)
-        delay(10)
+        delay(responseDelay)
         throwableToThrow?.let {
             throw it
         } ?: run {
@@ -65,7 +66,7 @@ internal class FakeTokenService : TokenService {
         grantType: String,
     ): UpgradeResponse {
         calls.add(CallType.Upgrade)
-        delay(10)
+        delay(responseDelay)
         throwableToThrow?.let {
             throw it
         } ?: run {

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/LoginRepositoryTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/LoginRepositoryTest.kt
@@ -38,6 +38,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import java.util.Locale
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeAll
@@ -80,10 +81,16 @@ class LoginRepositoryTest {
             authConfig,
             timeProvider,
             CodeChallengeBuilder(),
-            LoginUriBuilder(TEST_CLIENT_ID, TEST_CLIENT_UNIQUE_KEY, loginBaseUrl, authConfig.scopes),
+            LoginUriBuilder(
+                TEST_CLIENT_ID,
+                TEST_CLIENT_UNIQUE_KEY,
+                loginBaseUrl,
+                authConfig.scopes
+            ),
             loginService,
             tokensStore,
             retryPolicy,
+            Mutex(),
             bus,
         )
     }
@@ -503,7 +510,8 @@ class LoginRepositoryTest {
                 "In case of 5xx returns, initializeDeviceLogin should trigger retries as defined by the retryPolicy"
             }
             assert(
-                ((result as AuthResult.Failure).message as RetryableError).code == testErrorCode.toString(),
+                ((result as AuthResult.Failure).message as RetryableError).code ==
+                    testErrorCode.toString(),
             ) {
                 "When finished retrying, a RetryableError should be returned that cointains the correct error code."
             }

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/TokenMutexTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/TokenMutexTest.kt
@@ -1,0 +1,124 @@
+package com.tidal.sdk.auth
+
+import com.tidal.sdk.auth.login.CodeChallengeBuilder
+import com.tidal.sdk.auth.login.FakeTokensStore
+import com.tidal.sdk.auth.login.LoginRepository
+import com.tidal.sdk.auth.login.LoginUriBuilder
+import com.tidal.sdk.auth.model.AuthConfig
+import com.tidal.sdk.auth.util.RetryPolicy
+import com.tidal.sdk.common.TidalMessage
+import com.tidal.sdk.util.TEST_CLIENT_ID
+import com.tidal.sdk.util.TEST_CLIENT_UNIQUE_KEY
+import com.tidal.sdk.util.TEST_TIME_PROVIDER
+import com.tidal.sdk.util.makeCredentials
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class TokenMutexTest {
+
+    private var timeProvider = TEST_TIME_PROVIDER
+    private val authConfig = AuthConfig(
+        clientId = TEST_CLIENT_ID,
+        clientUniqueKey = TEST_CLIENT_UNIQUE_KEY,
+        clientSecret = "myVeryBestSecret",
+        credentialsKey = "credentialsKey",
+        scopes = setOf(),
+        enableCertificatePinning = false,
+    )
+
+    private val tokenMutex = Mutex()
+    private lateinit var fakeTokensStore: FakeTokensStore
+    private lateinit var fakeLoginService: FakeLoginService
+    private lateinit var loginRepository: LoginRepository
+
+    private val messageBus: MutableSharedFlow<TidalMessage> = MutableSharedFlow()
+    private val testRetryPolicy = object : RetryPolicy {
+        override val numberOfRetries = 1
+        override val delayMillis = 1
+        override val delayFactor = 1
+    }
+
+    private lateinit var fakeTokenService: FakeTokenService
+    private lateinit var tokenRepository: TokenRepository
+
+    private fun createLoginRepository(
+        loginService: FakeLoginService,
+        tokensStore: FakeTokensStore = FakeTokensStore(""),
+        retryPolicy: RetryPolicy = testRetryPolicy,
+        bus: MutableSharedFlow<TidalMessage> = messageBus,
+        loginBaseUrl: String = "https://login.tidal.com/",
+    ) {
+        fakeLoginService = loginService
+        fakeTokensStore = tokensStore
+        loginRepository = LoginRepository(
+            authConfig,
+            timeProvider,
+            CodeChallengeBuilder(),
+            LoginUriBuilder(
+                TEST_CLIENT_ID,
+                TEST_CLIENT_UNIQUE_KEY,
+                loginBaseUrl,
+                authConfig.scopes,
+            ),
+            loginService,
+            tokensStore,
+            retryPolicy,
+            tokenMutex,
+            bus,
+        )
+    }
+
+    private fun createTokenRepository(
+        tokenService: FakeTokenService,
+        tokensStore: FakeTokensStore = FakeTokensStore(authConfig.credentialsKey),
+        defaultRetrypolicy: RetryPolicy = testRetryPolicy,
+        upgradeRetryPolicy: RetryPolicy = testRetryPolicy,
+        bus: MutableSharedFlow<TidalMessage> = messageBus,
+    ) {
+        fakeTokenService = tokenService
+        fakeTokensStore = tokensStore
+        tokenRepository = TokenRepository(
+            authConfig,
+            TEST_TIME_PROVIDER,
+            tokensStore,
+            tokenService,
+            defaultRetrypolicy,
+            upgradeRetryPolicy,
+            tokenMutex,
+            bus,
+        )
+    }
+
+    @Test
+    fun `setCredentials execution waits until in-flight requests are done`() = runTest {
+        // given
+        createTokenRepository(FakeTokenService().apply { responseDelay = 1000 })
+        createLoginRepository(FakeLoginService(), tokensStore = fakeTokensStore)
+
+        val credentials = makeCredentials(clientId = "myForcedClientId", isExpired = true)
+        val refreshToken = "myMostRefreshingToken"
+
+        // when
+        val firstJob = launch {
+            tokenRepository.getCredentials(null)
+        }
+        val secondJob = launch {
+            delay(10)
+            loginRepository.setCredentials(credentials, refreshToken)
+        }
+        firstJob.join()
+        secondJob.join()
+
+        // then
+        assert(fakeTokensStore.tokensList.first().refreshToken == null) {
+            "The first saved Tokens should not contain a refreshToken, as none was set and we aren't logged in"
+        }
+        assert(
+            fakeTokensStore.tokensList.last().refreshToken == refreshToken,
+        ) { "The last saved Tokens should contain the refreshToken we have saved" }
+    }
+}

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/TokenRepositoryTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/TokenRepositoryTest.kt
@@ -20,6 +20,7 @@ import com.tidal.sdk.util.makeCredentials
 import java.io.IOException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -55,6 +56,7 @@ class TokenRepositoryTest {
             tokenService,
             defaultRetrypolicy,
             upgradeRetryPolicy,
+            Mutex(),
             bus,
         )
     }

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/storage/DefaultTokensStoreMigrationsTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/storage/DefaultTokensStoreMigrationsTest.kt
@@ -57,7 +57,6 @@ class DefaultTokensStoreMigrationsTest {
         val result = defaultTokensStore.getLatestTokens(testCredentialsKey)
 
         // then
-        println(result)
         assertEquals(expected, result)
     }
 
@@ -86,7 +85,6 @@ class DefaultTokensStoreMigrationsTest {
         val result = defaultTokensStore.getLatestTokens(testCredentialsKey)
 
         // then
-        println(result)
         assertEquals(expected, result)
     }
 }


### PR DESCRIPTION
This fix makes auth networking more robust and predictable. While under normal circumstances the changes added here don't have an effect, making sure our `SharedPreferences` editing is synchronized with backend calls is necessary to enable certain types of UI tests (such as our benchmark tests) to run, as `setCredentials` can be called at any time.

When calling `setCredential`s, we essentially force credentials to be saved in the auth module's storage.
If we do this while a request for token update is in flight, we run the risk that upon return of that request, the credentials you just saved to be overwritten immediately.

This change fixes that by changing how our network calls are synchronized using a `Mutex`:
- it is now shared between `LoginRepository` and `TokenRepository`
- `setCredentials` is now synced too, making sure it will wait for all previously issued `getCredentials` calls to finish.

All following calls to `getCredentials` will be based on whatever was saved using `setCredentials`, so this change effectively prevents accidental overwrites for tests and other automated orchestration.
