### PR TITLE
Sort out token refresh and saving synchronization II

### DIFF
--- a/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/TokenRepository.kt
@@ -8,6 +8,7 @@ import com.tidal.sdk.auth.model.RefreshResponse
 import com.tidal.sdk.auth.model.Tokens
 import com.tidal.sdk.auth.model.failure
 import com.tidal.sdk.auth.model.success
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import com.tidal.sdk.auth.storage.TokensStore
 import com.tidal.sdk.auth.token.TokenService
 import com.tidal.sdk.auth.util.RetryPolicy
@@ -33,6 +34,7 @@ internal class TokenRepository(
     private val defaultBackoffPolicy: RetryPolicy,
     private val upgradeBackoffPolicy: RetryPolicy,
     private val bus: MutableSharedFlow<TidalMessage>,
+    private val networkingJobHandler: NetworkingJobHandler,
 ) {
 
     /**

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/di/AuthComponent.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/di/AuthComponent.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.auth.di
 import android.content.Context
 import com.tidal.sdk.auth.TidalAuth
 import com.tidal.sdk.auth.model.AuthConfig
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
@@ -27,6 +28,7 @@ interface AuthComponent {
         fun create(
             @BindsInstance context: Context,
             @BindsInstance config: AuthConfig,
+            @BindsInstance jobHandler: NetworkingJobHandler = NetworkingJobHandler(),
         ): AuthComponent
     }
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/di/CredentialsModule.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/di/CredentialsModule.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.auth.di
 
 import com.tidal.sdk.auth.TokenRepository
 import com.tidal.sdk.auth.model.AuthConfig
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import com.tidal.sdk.auth.storage.TokensStore
 import com.tidal.sdk.auth.token.TokenService
 import com.tidal.sdk.auth.util.RetryPolicy
@@ -25,9 +26,9 @@ internal class CredentialsModule {
 
     @Provides
     @Singleton
-    fun provideTokenService(retrofit: Retrofit): TokenService {
-        return retrofit.create(TokenService::class.java)
-    }
+    fun provideTokenService(
+        retrofit: Retrofit,
+    ): TokenService = retrofit.create(TokenService::class.java)
 
     @Singleton
     @Provides
@@ -39,6 +40,7 @@ internal class CredentialsModule {
         @Named("default") defaultBackoffPolicy: RetryPolicy,
         @Named("upgrade") upgradeBackoffPolicy: RetryPolicy,
         bus: MutableSharedFlow<TidalMessage>,
+        networkingJobHandler: NetworkingJobHandler,
     ) = TokenRepository(
         authConfig,
         timeProvider,
@@ -47,5 +49,6 @@ internal class CredentialsModule {
         defaultBackoffPolicy,
         upgradeBackoffPolicy,
         bus,
+        networkingJobHandler
     )
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/di/LoginModule.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/di/LoginModule.kt
@@ -6,6 +6,7 @@ import com.tidal.sdk.auth.login.LoginRepository
 import com.tidal.sdk.auth.login.LoginUriBuilder
 import com.tidal.sdk.auth.model.AuthConfig
 import com.tidal.sdk.auth.network.LoginService
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import com.tidal.sdk.auth.storage.TokensStore
 import com.tidal.sdk.auth.util.RetryPolicy
 import com.tidal.sdk.auth.util.TimeProvider
@@ -60,6 +61,7 @@ internal class LoginModule {
         tokensStore: TokensStore,
         @Named("default") retryPolicy: RetryPolicy,
         bus: MutableSharedFlow<TidalMessage>,
+        networkingJobHandler: NetworkingJobHandler,
     ): LoginRepository = LoginRepository(
         authConfig,
         timeProvider,
@@ -69,5 +71,6 @@ internal class LoginModule {
         tokensStore,
         retryPolicy,
         bus,
+        networkingJobHandler,
     )
 }

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/login/LoginRepository.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/login/LoginRepository.kt
@@ -11,6 +11,7 @@ import com.tidal.sdk.auth.model.LoginResponse
 import com.tidal.sdk.auth.model.Tokens
 import com.tidal.sdk.auth.model.failure
 import com.tidal.sdk.auth.network.LoginService
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import com.tidal.sdk.auth.storage.TokensStore
 import com.tidal.sdk.auth.util.RetryPolicy
 import com.tidal.sdk.auth.util.TimeProvider
@@ -30,6 +31,7 @@ internal class LoginRepository constructor(
     private val tokensStore: TokensStore,
     private val exponentialBackoffPolicy: RetryPolicy,
     private val bus: MutableSharedFlow<TidalMessage>,
+    private val networkingJobHandler: NetworkingJobHandler,
 ) {
 
     private var codeVerifier: String? = null

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/network/NetworkingJobHandler.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/network/NetworkingJobHandler.kt
@@ -1,12 +1,10 @@
 package com.tidal.sdk.auth.network
 
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 
-class NetworkingJobHandler(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-    val scope = CoroutineScope(dispatcher)
+class NetworkingJobHandler(val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)) {
 
     val jobs = mutableListOf<Job>()
 

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/network/NetworkingJobHandler.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/network/NetworkingJobHandler.kt
@@ -1,0 +1,17 @@
+package com.tidal.sdk.auth.network
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+
+class NetworkingJobHandler(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
+    val scope = CoroutineScope(dispatcher)
+
+    val jobs = mutableListOf<Job>()
+
+    fun cancelAllJobs() {
+        jobs.forEach { it.cancel() }
+        jobs.clear()
+    }
+}

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/FakeTokenService.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/FakeTokenService.kt
@@ -9,6 +9,7 @@ internal class FakeTokenService : TokenService {
 
     var calls = mutableListOf<CallType>()
     var throwableToThrow: Throwable? = null
+    var responseDelay = 10L
 
     override suspend fun getTokenFromRefreshToken(
         clientId: String,
@@ -18,7 +19,7 @@ internal class FakeTokenService : TokenService {
         scope: String,
     ): RefreshResponse {
         calls.add(CallType.Refresh)
-        delay(10)
+        delay(responseDelay)
         throwableToThrow?.let {
             throw it
         } ?: run {
@@ -41,7 +42,7 @@ internal class FakeTokenService : TokenService {
         scope: String,
     ): RefreshResponse {
         calls.add(CallType.Secret)
-        delay(10)
+        delay(responseDelay)
         throwableToThrow?.let {
             throw it
         } ?: run {
@@ -65,7 +66,7 @@ internal class FakeTokenService : TokenService {
         grantType: String,
     ): UpgradeResponse {
         calls.add(CallType.Upgrade)
-        delay(10)
+        delay(responseDelay)
         throwableToThrow?.let {
             throw it
         } ?: run {

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/LoginRepositoryTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/LoginRepositoryTest.kt
@@ -22,6 +22,7 @@ import com.tidal.sdk.auth.model.LoginResponse
 import com.tidal.sdk.auth.model.QueryParameter
 import com.tidal.sdk.auth.model.TokenResponseError
 import com.tidal.sdk.auth.model.Tokens
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import com.tidal.sdk.auth.util.RetryPolicy
 import com.tidal.sdk.auth.util.TimeProvider
 import com.tidal.sdk.common.NetworkError
@@ -80,11 +81,17 @@ class LoginRepositoryTest {
             authConfig,
             timeProvider,
             CodeChallengeBuilder(),
-            LoginUriBuilder(TEST_CLIENT_ID, TEST_CLIENT_UNIQUE_KEY, loginBaseUrl, authConfig.scopes),
+            LoginUriBuilder(
+                TEST_CLIENT_ID,
+                TEST_CLIENT_UNIQUE_KEY,
+                loginBaseUrl,
+                authConfig.scopes
+            ),
             loginService,
             tokensStore,
             retryPolicy,
             bus,
+            NetworkingJobHandler(),
         )
     }
 

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/SetCredentialsTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/SetCredentialsTest.kt
@@ -1,0 +1,163 @@
+package com.tidal.sdk.auth
+
+import com.tidal.sdk.auth.login.CodeChallengeBuilder
+import com.tidal.sdk.auth.login.FakeTokensStore
+import com.tidal.sdk.auth.login.LoginRepository
+import com.tidal.sdk.auth.login.LoginUriBuilder
+import com.tidal.sdk.auth.model.AuthConfig
+import com.tidal.sdk.auth.model.AuthResult
+import com.tidal.sdk.auth.model.Credentials
+import com.tidal.sdk.auth.network.NetworkingJobHandler
+import com.tidal.sdk.auth.util.RetryPolicy
+import com.tidal.sdk.common.TidalMessage
+import com.tidal.sdk.util.TEST_CLIENT_ID
+import com.tidal.sdk.util.TEST_CLIENT_UNIQUE_KEY
+import com.tidal.sdk.util.TEST_TIME_PROVIDER
+import com.tidal.sdk.util.makeCredentials
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class SetCredentialsTest {
+
+    private var timeProvider = TEST_TIME_PROVIDER
+    private val authConfig = AuthConfig(
+        clientId = TEST_CLIENT_ID,
+        clientUniqueKey = TEST_CLIENT_UNIQUE_KEY,
+        clientSecret = "myVeryBestSecret",
+        credentialsKey = "credentialsKey",
+        scopes = setOf(),
+        enableCertificatePinning = false,
+    )
+
+    private lateinit var fakeTokensStore: FakeTokensStore
+    private lateinit var fakeLoginService: FakeLoginService
+    private lateinit var loginRepository: LoginRepository
+
+    private val messageBus: MutableSharedFlow<TidalMessage> = MutableSharedFlow()
+    private val testRetryPolicy = object : RetryPolicy {
+        override val numberOfRetries = 1
+        override val delayMillis = 1
+        override val delayFactor = 1
+    }
+
+    private lateinit var fakeTokenService: FakeTokenService
+    private lateinit var tokenRepository: TokenRepository
+
+    private fun createLoginRepository(
+        loginService: FakeLoginService,
+        tokensStore: FakeTokensStore = FakeTokensStore(""),
+        retryPolicy: RetryPolicy = testRetryPolicy,
+        bus: MutableSharedFlow<TidalMessage> = messageBus,
+        loginBaseUrl: String = "https://login.tidal.com/",
+        networkingJobHandler: NetworkingJobHandler,
+    ) {
+        fakeLoginService = loginService
+        fakeTokensStore = tokensStore
+        loginRepository = LoginRepository(
+            authConfig,
+            timeProvider,
+            CodeChallengeBuilder(),
+            LoginUriBuilder(
+                TEST_CLIENT_ID,
+                TEST_CLIENT_UNIQUE_KEY,
+                loginBaseUrl,
+                authConfig.scopes,
+            ),
+            loginService,
+            tokensStore,
+            retryPolicy,
+            bus,
+            networkingJobHandler,
+        )
+    }
+
+    private fun createTokenRepository(
+        tokenService: FakeTokenService,
+        tokensStore: FakeTokensStore = FakeTokensStore(authConfig.credentialsKey),
+        defaultRetrypolicy: RetryPolicy = testRetryPolicy,
+        upgradeRetryPolicy: RetryPolicy = testRetryPolicy,
+        bus: MutableSharedFlow<TidalMessage> = messageBus,
+        networkingJobHandler: NetworkingJobHandler,
+    ) {
+        fakeTokenService = tokenService
+        fakeTokensStore = tokensStore
+        tokenRepository = TokenRepository(
+            authConfig,
+            TEST_TIME_PROVIDER,
+            tokensStore,
+            tokenService,
+            defaultRetrypolicy,
+            upgradeRetryPolicy,
+            bus,
+            networkingJobHandler,
+        )
+    }
+
+    @Test
+    fun `setCredentials should cancel jobs requesting the token endpoint`() = runTest {
+        // given
+        val networkingJobHandler = NetworkingJobHandler(this)
+        createTokenRepository(
+            FakeTokenService().apply { responseDelay = 1000 },
+            networkingJobHandler = networkingJobHandler,
+        )
+        createLoginRepository(
+            FakeLoginService(),
+            tokensStore = fakeTokensStore,
+            networkingJobHandler = networkingJobHandler,
+        )
+
+        val credentials =
+            makeCredentials(
+                userId = "myLittleUser",
+                clientId = authConfig.clientId,
+                isExpired = false
+            )
+        val refreshToken = "myMostRefreshingToken"
+        val jobs = mutableListOf<Job>()
+        val cancelledCreds = mutableListOf<AuthResult<Credentials>>()
+
+        // when
+        (0..3).forEach { _ ->
+            jobs.add(
+                launch {
+                    cancelledCreds.add(tokenRepository.getCredentials(null))
+                }
+            )
+        }
+
+        jobs.add(
+            launch {
+                delay(10)
+                loginRepository.setCredentials(credentials, refreshToken)
+            }
+        )
+        jobs.forEach { it.join() }
+
+        // then
+        assert(fakeTokensStore.tokensList.size == 1) {
+            "Since getCredentials gets cancelled, we should only have one set of Tokens saved"
+        }
+        assert(
+            fakeTokensStore.tokensList.first().refreshToken == refreshToken,
+        ) { "The saved Tokens should contain the refreshToken we passed to setCredentials" }
+        assert(cancelledCreds.all { it is AuthResult.Failure }) {
+            "All cancelled jobs should have returned a failure"
+        }
+
+        // when
+        val savedCreds = tokenRepository.getCredentials(null)
+        println(savedCreds)
+        // then
+        assert(savedCreds is AuthResult.Success) {
+            "getCredentials after setCredentials should return a success"
+        }
+        assert((savedCreds as AuthResult.Success).data == credentials) {
+            "The saved credentials should be the same as the ones we set"
+        }
+    }
+}

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/TokenRepositoryTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/TokenRepositoryTest.kt
@@ -46,6 +46,7 @@ class TokenRepositoryTest {
         defaultRetrypolicy: RetryPolicy = testRetryPolicy,
         upgradeRetryPolicy: RetryPolicy = testRetryPolicy,
         bus: MutableSharedFlow<TidalMessage> = messageBus,
+        networkingJobHandler: NetworkingJobHandler,
     ) {
         fakeTokenService = tokenService
         fakeTokensStore = tokensStore
@@ -57,7 +58,7 @@ class TokenRepositoryTest {
             defaultRetrypolicy,
             upgradeRetryPolicy,
             bus,
-            NetworkingJobHandler(),
+            networkingJobHandler,
         )
     }
 
@@ -93,7 +94,7 @@ class TokenRepositoryTest {
             credentials,
             "refreshToken",
         )
-        createTokenRepository(FakeTokenService())
+        createTokenRepository(FakeTokenService(), networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
 
         // when
@@ -112,7 +113,10 @@ class TokenRepositoryTest {
     fun `getCredentials returns Credentials without token if called when logged out and no clientSecret is set`() =
         runTest {
             // given
-            createTokenRepository(FakeTokenService())
+            createTokenRepository(
+                FakeTokenService(),
+                networkingJobHandler = NetworkingJobHandler(this),
+            )
 
             // when
             val result = tokenRepository.getCredentials(null)
@@ -135,7 +139,10 @@ class TokenRepositoryTest {
                 credentials,
                 "refreshToken",
             )
-            createTokenRepository(FakeTokenService())
+            createTokenRepository(
+                FakeTokenService(),
+                networkingJobHandler = NetworkingJobHandler(this),
+            )
             fakeTokensStore.saveTokens(tokens)
 
             // when
@@ -161,7 +168,7 @@ class TokenRepositoryTest {
             credentials,
             "refreshToken",
         )
-        createTokenRepository(FakeTokenService())
+        createTokenRepository(FakeTokenService(), networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
         ApiErrorSubStatus.entries.filter { it.shouldTriggerRefresh }.forEach { status ->
             // when
@@ -186,7 +193,10 @@ class TokenRepositoryTest {
                 credentials,
                 "refreshToken",
             )
-            createTokenRepository(FakeTokenService())
+            createTokenRepository(
+                FakeTokenService(),
+                networkingJobHandler = NetworkingJobHandler(this),
+            )
             fakeTokensStore.saveTokens(tokens)
 
             // when
@@ -213,7 +223,7 @@ class TokenRepositoryTest {
                 throwableToThrow = buildTestHttpException(503)
             }
             val expectedCalls = testRetryPolicy.numberOfRetries + 1
-            createTokenRepository(service)
+            createTokenRepository(service, networkingJobHandler = NetworkingJobHandler(this))
             fakeTokensStore.saveTokens(tokens)
 
             // when
@@ -246,7 +256,7 @@ class TokenRepositoryTest {
         val service = FakeTokenService().apply {
             throwableToThrow = buildTestHttpException(400)
         }
-        createTokenRepository(service)
+        createTokenRepository(service, networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
 
         // when
@@ -282,7 +292,7 @@ class TokenRepositoryTest {
         val service = FakeTokenService().apply {
             throwableToThrow = buildTestHttpException(401)
         }
-        createTokenRepository(service)
+        createTokenRepository(service, networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
 
         // when
@@ -315,7 +325,7 @@ class TokenRepositoryTest {
             credentials,
             "refreshToken",
         )
-        createTokenRepository(FakeTokenService())
+        createTokenRepository(FakeTokenService(), networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
 
         // when
@@ -340,7 +350,10 @@ class TokenRepositoryTest {
                     credentials,
                     "refreshToken",
                 )
-                createTokenRepository(FakeTokenService())
+                createTokenRepository(
+                    FakeTokenService(),
+                    networkingJobHandler = NetworkingJobHandler(this),
+                )
                 fakeTokensStore.saveTokens(tokens)
 
                 // when
@@ -367,7 +380,10 @@ class TokenRepositoryTest {
             )
             val secret = "myLittleSecret"
             createAuthConfig(secret = secret)
-            createTokenRepository(FakeTokenService())
+            createTokenRepository(
+                FakeTokenService(),
+                networkingJobHandler = NetworkingJobHandler(this),
+            )
             fakeTokensStore.saveTokens(tokens)
 
             // when
@@ -392,7 +408,10 @@ class TokenRepositoryTest {
             // given
             val secret = "myLittleSecret"
             createAuthConfig(secret = secret)
-            createTokenRepository(FakeTokenService())
+            createTokenRepository(
+                FakeTokenService(),
+                networkingJobHandler = NetworkingJobHandler(this),
+            )
 
             // when
             tokenRepository.getCredentials(null)
@@ -424,7 +443,10 @@ class TokenRepositoryTest {
             )
             val secret = "myLittleSecret"
             createAuthConfig(secret = secret)
-            createTokenRepository(FakeTokenService())
+            createTokenRepository(
+                FakeTokenService(),
+                networkingJobHandler = NetworkingJobHandler(this),
+            )
             fakeTokensStore.saveTokens(tokens)
 
             // when
@@ -457,7 +479,7 @@ class TokenRepositoryTest {
         )
         val secret = "myLittleSecret"
         createAuthConfig(secret = secret)
-        createTokenRepository(FakeTokenService())
+        createTokenRepository(FakeTokenService(), networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
 
         // when
@@ -506,6 +528,7 @@ class TokenRepositoryTest {
         createTokenRepository(
             tokenService = FakeTokenService(),
             tokensStore = fakeTokensStore,
+            networkingJobHandler = NetworkingJobHandler(this),
         )
 
         val result = tokenRepository.getCredentials(null)
@@ -549,6 +572,7 @@ class TokenRepositoryTest {
             },
             tokensStore = fakeTokensStore,
             upgradeRetryPolicy = UpgradeTokenRetryPolicy(),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
         val expectedRetries = upgradeRetryPolicy.numberOfRetries + 1
         tokenRepository.getCredentials(null)
@@ -567,6 +591,7 @@ class TokenRepositoryTest {
             },
             tokensStore = fakeTokensStore,
             upgradeRetryPolicy = UpgradeTokenRetryPolicy(),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
         tokenRepository.getCredentials(null)
 
@@ -584,6 +609,7 @@ class TokenRepositoryTest {
             },
             tokensStore = fakeTokensStore,
             upgradeRetryPolicy = UpgradeTokenRetryPolicy(),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
         tokenRepository.getCredentials(null)
 
@@ -619,6 +645,8 @@ class TokenRepositoryTest {
             },
             tokensStore = fakeTokensStore,
             upgradeRetryPolicy = UpgradeTokenRetryPolicy(),
+            networkingJobHandler = NetworkingJobHandler(this),
+
         )
         val result1 = tokenRepository.getCredentials(null)
 
@@ -629,6 +657,7 @@ class TokenRepositoryTest {
             },
             tokensStore = fakeTokensStore,
             upgradeRetryPolicy = UpgradeTokenRetryPolicy(),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
         fakeTokenService.throwableToThrow = buildTestHttpException(401)
         val result2 = tokenRepository.getCredentials(null)
@@ -640,6 +669,7 @@ class TokenRepositoryTest {
             },
             tokensStore = fakeTokensStore,
             upgradeRetryPolicy = UpgradeTokenRetryPolicy(),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
         fakeTokenService.throwableToThrow = buildTestHttpException(503)
         val result3 = tokenRepository.getCredentials(null)
@@ -663,7 +693,7 @@ class TokenRepositoryTest {
             credentials,
             "refreshToken",
         )
-        createTokenRepository(FakeTokenService())
+        createTokenRepository(FakeTokenService(), networkingJobHandler = NetworkingJobHandler(this))
         fakeTokensStore.saveTokens(tokens)
 
         // when
@@ -698,6 +728,7 @@ class TokenRepositoryTest {
         createTokenRepository(
             FakeTokenService(),
             FakeTokensStore(authConfig.credentialsKey, tokens),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
 
         // when
@@ -731,6 +762,7 @@ class TokenRepositoryTest {
         createTokenRepository(
             FakeTokenService(),
             FakeTokensStore(authConfig.credentialsKey, tokens),
+            networkingJobHandler = NetworkingJobHandler(this),
         )
 
         val numberOfThreads = 100
@@ -764,7 +796,11 @@ class TokenRepositoryTest {
         fakeTokensStore = FakeTokensStore(authConfig.credentialsKey).apply {
             saveTokens(tokens)
         }
-        createTokenRepository(tokenService, fakeTokensStore)
+        createTokenRepository(
+            tokenService,
+            fakeTokensStore,
+            networkingJobHandler = NetworkingJobHandler(this),
+        )
 
         // when
         tokenRepository.getCredentials(null)

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/TokenRepositoryTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/TokenRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.tidal.sdk.auth.model.AuthConfig
 import com.tidal.sdk.auth.model.AuthResult
 import com.tidal.sdk.auth.model.CredentialsUpdatedMessage
 import com.tidal.sdk.auth.model.Tokens
+import com.tidal.sdk.auth.network.NetworkingJobHandler
 import com.tidal.sdk.auth.util.RetryPolicy
 import com.tidal.sdk.auth.util.UpgradeTokenRetryPolicy
 import com.tidal.sdk.auth.util.buildTestHttpException
@@ -56,6 +57,7 @@ class TokenRepositoryTest {
             defaultRetrypolicy,
             upgradeRetryPolicy,
             bus,
+            NetworkingJobHandler(),
         )
     }
 


### PR DESCRIPTION
This PR adds a `NetworkingJobHandler` which can be used to cancel token refresh calls. 

This is needed e.g. when calling `setCredentials`, as otherwise a call to `getCredentials` that was issued before, but returns after this operation can overwrite and erase the credentials just set.

This is an alternative approach to solving the same problem https://github.com/tidal-music/tidal-sdk-android/pull/101 addresses. 