### PR TITLE
Use Handler for Auth

### DIFF
--- a/auth/src/main/kotlin/com/tidal/sdk/auth/GetCredentialsRunnable.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/GetCredentialsRunnable.kt
@@ -1,0 +1,30 @@
+package com.tidal.sdk.auth
+
+import com.tidal.sdk.auth.model.Credentials
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+
+internal class GetCredentialsRunnable(
+    @Assisted
+    private val apiErrorSubStatus: String?,
+    @Assisted
+    private val callback: (Credentials) -> Unit,
+    private val depsYouNeedToGetTheToken,
+) : Runnable {
+
+    override fun run() {
+        // Here you move what you had in TokenRepository.getCredentials, but simpler because it has
+        // to be synchronous, so you get rid of all the suspend stuff (e.g. the network calls).
+        // Asynchronicity is built via the Handler's thread and exposed as a suspend function
+        // thanks to suspendCancellableCoroutine
+        callback(otherDepsYouNeedToGetTheToken.getCredentials)
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            apiErrorSubStatus: String?,
+            callback: (Credentials) -> Unit,
+        ): GetCredentialsRunnable
+    }
+}

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/SetCredentialsRunnable.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/SetCredentialsRunnable.kt
@@ -1,0 +1,28 @@
+package com.tidal.sdk.auth
+
+import com.tidal.sdk.auth.model.Credentials
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+
+internal class SetCredentialsRunnable(
+    @Assisted
+    private val newToken: Credentials,
+    @Assisted
+    private val callback: (Credentials) -> Unit,
+    private val depsYouNeedToSetTheToken,
+) : Runnable {
+    override fun run() {
+        // Here you move what you had in LoginRepository.setCredentials. The only suspend stuff you
+        // had there was was bus.emit, but you can use bus.tryEmit instead.
+        depsYouNeedToSetTheToken.set(newToken)
+        callback(this)
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            newToken: Credentials,
+            callback: (Runnable) -> Unit
+        ): SetCredentialsRunnable
+    }
+}


### PR DESCRIPTION
This showcases how to use Handler to solve the problem of interrupting ongoing getCredentials calls when a setCredentials happens. The gaps to fill are Auth stuff - no knowledge about Handler is required really, that is what I have taken care of.

Note also that you can probably use the mutex instead of the synchronized blocks I have written, I'm just more familiar with synchronized.