### PR TITLE
Bump auth version to 0.10.2

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2024-09-17
+### Changed
+- Ensure that setting credentials manually is synced with retrieving them from the backend. This prevents accidental overwrites in local storage.
+
 ## [0.10.1] - 2024-08-22
 ### Fixed
 - Fix bug that prevented version 0.10.0 from properly deserializing data stored by older versions

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Auth module manages app authentication, authorization, and token handling, simplifying OAuth processes, ensuring secure user access, and offering robust error handling.
-version=0.10.1
+version=0.10.2


### PR DESCRIPTION
This new version contains a change that ensures that setting credentials manually is synced with retrieving them from the backend. This prevents accidental overwrites in local storage.