### PR TITLE
MF-464: Explictly remove cache keys that come from InvalidResponseCodeException

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
@@ -57,6 +57,7 @@ import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayerFactory
 import com.tidal.sdk.player.playbackengine.player.PlayerCache
 import com.tidal.sdk.player.playbackengine.quality.AudioQualityRepository
 import com.tidal.sdk.player.playbackengine.util.SynchronousSurfaceHolder
+import com.tidal.sdk.player.playbackengine.util.clear
 import com.tidal.sdk.player.playbackengine.view.AspectRatioAdjustingSurfaceView
 import com.tidal.sdk.player.playbackengine.volume.VolumeHelper
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
@@ -810,11 +811,7 @@ internal class ExoPlayerPlaybackEngine(
         while (crawler?.cause != null) {
             @Suppress("MagicNumber")
             if ((crawler as? InvalidResponseCodeException)?.responseCode == 416) {
-                with(playerCache.cache) {
-                    keys.forEach {
-                        removeResource(it)
-                    }
-                }
+                playerCache.clear()
             }
             crawler = crawler.cause
             errorMessage += " -> ${crawler?.message}"

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/ExtendedExoPlayer.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/ExtendedExoPlayer.kt
@@ -16,7 +16,6 @@ import kotlin.properties.Delegates
  * A proxy to an [ExoPlayer] instance which defines requirements for additional functionality to
  * satisfy library capabilities.
  * @param delegate An [ExoPlayer] instance that all calls needing one will utilize.
- * @param playerCache A [PlayerCache] instance that will be used to cache assets.
  * @param loadControl A [LoadControl] instance that controls the buffering of media.
  * @param mediaSourcerer A [MediaSourcerer] instance that holds the MediaSource of what we play.
  * @param extendedExoPlayerState A [ExtendedExoPlayerState] instance that holds the some shared
@@ -24,7 +23,6 @@ import kotlin.properties.Delegates
  */
 internal class ExtendedExoPlayer(
     private val delegate: ExoPlayer,
-    private val playerCache: PlayerCache,
     private val loadControl: LoadControl,
     private val mediaSourcerer: MediaSourcerer,
     private val extendedExoPlayerState: ExtendedExoPlayerState,
@@ -80,9 +78,6 @@ internal class ExtendedExoPlayer(
 
     override fun release() {
         delegate.release()
-        if (playerCache is PlayerCache.Internal) {
-            playerCache.cache.release()
-        }
         mediaSourcerer.release()
         extendedExoPlayerState.playbackInfoListener = null
         analyticsListener = null

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ExtendedExoPlayerModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ExtendedExoPlayerModule.kt
@@ -19,7 +19,6 @@ import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayer
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayerState
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayerStateUpdateRunnable
-import com.tidal.sdk.player.playbackengine.player.PlayerCache
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
@@ -96,13 +95,11 @@ internal object ExtendedExoPlayerModule {
     @ExtendedExoPlayerComponent.Scoped
     fun extendedExoPlayer(
         exoPlayer: ExoPlayer,
-        playerCache: PlayerCache,
         loadControl: LoadControl,
         mediaSourcerer: MediaSourcerer,
         extendedExoPlayerState: ExtendedExoPlayerState,
     ) = ExtendedExoPlayer(
         exoPlayer,
-        playerCache,
         loadControl,
         mediaSourcerer,
         extendedExoPlayerState,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
@@ -1,15 +1,10 @@
 package com.tidal.sdk.player.playbackengine.player.di
 
-import android.content.Context
 import androidx.media3.common.C
-import androidx.media3.database.DatabaseProvider
-import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.FileDataSource
 import androidx.media3.datasource.cache.CacheDataSink
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheKeyFactory
-import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
-import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.dash.DashMediaSource
@@ -68,7 +63,6 @@ import com.tidal.sdk.player.playbackengine.offline.OfflineStorageProvider
 import com.tidal.sdk.player.playbackengine.offline.StorageDataSource
 import com.tidal.sdk.player.playbackengine.offline.cache.OfflineCacheProvider
 import com.tidal.sdk.player.playbackengine.playbackprivilege.PlaybackPrivilegeProvider
-import com.tidal.sdk.player.playbackengine.player.CacheProvider
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayerState
 import com.tidal.sdk.player.playbackengine.player.PlayerCache
 import com.tidal.sdk.player.playbackengine.quality.AudioQualityRepository
@@ -77,40 +71,16 @@ import com.tidal.sdk.player.streamingapi.StreamingApi
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
-import java.io.File
 import javax.inject.Named
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
 
-private const val CACHE_DIR = "exoplayer-cache"
 private const val MINIMUM_LOADABLE_RETRY_COUNT = 10
 
 @Module
 @Suppress("TooManyFunctions")
 internal object MediaSourcererModule {
-
-    @Provides
-    @ExtendedExoPlayerComponent.Scoped
-    fun provideDatabaseProvider(context: Context): DatabaseProvider =
-        StandaloneDatabaseProvider(context)
-
-    @Provides
-    @ExtendedExoPlayerComponent.Scoped
-    fun cache(
-        appSpecificCacheDir: File,
-        databaseProvider: DatabaseProvider,
-        cacheProvider: CacheProvider,
-    ): PlayerCache {
-        return when (cacheProvider) {
-            is CacheProvider.External -> PlayerCache.Provided(cacheProvider.cache)
-            is CacheProvider.Internal -> {
-                val cacheDir = File(appSpecificCacheDir, CACHE_DIR)
-                val cacheEvictor = LeastRecentlyUsedCacheEvictor(cacheProvider.cacheSizeBytes.value)
-                PlayerCache.Internal(SimpleCache(cacheDir, cacheEvictor, databaseProvider))
-            }
-        }
-    }
 
     @Provides
     @Reusable

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/util/PlayerCacheExtensions.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/util/PlayerCacheExtensions.kt
@@ -1,0 +1,11 @@
+package com.tidal.sdk.player.playbackengine.util
+
+import com.tidal.sdk.player.playbackengine.player.PlayerCache
+
+internal fun PlayerCache.clear() {
+    with(cache) {
+        keys.forEach {
+            removeResource(it)
+        }
+    }
+}

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/player/ExtendedExoPlayerTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/player/ExtendedExoPlayerTest.kt
@@ -33,14 +33,12 @@ import org.mockito.kotlin.whenever
 internal class ExtendedExoPlayerTest {
 
     private val delegate = mock<ExoPlayer>()
-    private val playerCache = mock<PlayerCache.Internal>()
     private val loadControl = mock<LoadControl>()
     private val mediaSourcerer = mock<MediaSourcerer>()
     private val extendedExoPlayerState = mock<ExtendedExoPlayerState>()
     private val extendedExoPlayer by lazy {
         ExtendedExoPlayer(
             delegate,
-            playerCache,
             loadControl,
             mediaSourcerer,
             extendedExoPlayerState,
@@ -155,7 +153,6 @@ internal class ExtendedExoPlayerTest {
         }
         val extendedExoPlayer = ExtendedExoPlayer(
             delegate,
-            playerCache,
             loadControl,
             mediaSourcerer,
             extendedExoPlayerState,
@@ -170,13 +167,9 @@ internal class ExtendedExoPlayerTest {
     }
 
     @Test
-    fun releaseForwardsToDelegateAndReleasesCache() {
-        val playerCache = mock<PlayerCache.Internal> {
-            on { cache } doReturn mock()
-        }
+    fun releaseForwardsToDelegate() {
         val extendedExoPlayer = ExtendedExoPlayer(
             delegate,
-            playerCache,
             loadControl,
             mediaSourcerer,
             extendedExoPlayerState,
@@ -185,7 +178,6 @@ internal class ExtendedExoPlayerTest {
         extendedExoPlayer.release()
 
         verify(delegate).release()
-        verify(playerCache.cache).release()
         verify(mediaSourcerer).release()
         verify(extendedExoPlayerState).playbackInfoListener = null
     }


### PR DESCRIPTION
This involves some changes to cache management since it used to live on a lower scope.