### PR TITLE
Update media3 to 1.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ retrofit = "2.11.0"
 room = "2.6.1"
 slf4j-api = "2.0.12"
 tickaroo = "0.8.13"
-tidal-androidx-media = "1.1.1.2"
+tidal-androidx-media = "1.2.1.1"
 plugins-tidal = "unspecified"
 
 [libraries]

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
@@ -76,7 +76,7 @@ private const val MS_IN_SECOND = 1000L
 /**
  * The default implementation of [PlaybackEngine] that will use ExoPlayer to play media.
  */
-@Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
+@Suppress("TooManyFunctions", "LargeClass", "LongParameterList", "UnsafeOptInUsageError")
 internal class ExoPlayerPlaybackEngine(
     private val coroutineScope: CoroutineScope,
     private val extendedExoPlayerFactory: ExtendedExoPlayerFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/PlayerLoadErrorHandlingPolicy.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/PlayerLoadErrorHandlingPolicy.kt
@@ -17,6 +17,7 @@ private const val MAX_5XX_RETRIES = 3
 private const val MAX_RETRY_INTERVAL_MS = 5_000L
 private const val TOO_MANY_REQUESTS_STATUS = 429
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlayerLoadErrorHandlingPolicy(
     private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
 ) : LoadErrorHandlingPolicy by loadErrorHandlingPolicy {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/TidalExtractorsFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/TidalExtractorsFactory.kt
@@ -7,6 +7,7 @@ import androidx.media3.extractor.mp3.Mp3Extractor
 import androidx.media3.extractor.mp4.FragmentedMp4Extractor
 import androidx.media3.extractor.mp4.Mp4Extractor
 
+@Suppress("UnsafeOptInUsageError")
 internal class TidalExtractorsFactory : ExtractorsFactory {
 
     override fun createExtractors(): Array<Extractor> {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/cache/DefaultCacheKeyFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/cache/DefaultCacheKeyFactory.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine.cache
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.cache.CacheKeyFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class DefaultCacheKeyFactory : CacheKeyFactory {
     override fun buildCacheKey(dataSpec: DataSpec) = dataSpec.uri.path.toString()
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/dash/DashManifestFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/dash/DashManifestFactory.kt
@@ -11,6 +11,7 @@ import java.nio.charset.Charset
  * Create ExoPlayer's [DashManifest] from our encoded [String] manifest, decoded with the provided
  * [base64Codec], then parsed with the provided [dashManifestParser].
  */
+@Suppress("UnsafeOptInUsageError")
 internal class DashManifestFactory(
     private val base64Codec: Base64Codec,
     private val dashManifestParser: ParsingLoadable.Parser<DashManifest>,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/CacheKeyAesCipherDataSourceFactoryFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/CacheKeyAesCipherDataSourceFactoryFactory.kt
@@ -6,6 +6,7 @@ import androidx.media3.datasource.cache.CacheKeyFactory
 import com.tidal.sdk.player.playbackengine.Encryption
 import com.tidal.sdk.player.playbackengine.offline.crypto.CacheKeyAesCipherDataSourceFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class CacheKeyAesCipherDataSourceFactoryFactory(
     private val cacheDataSourceFactory: CacheDataSource.Factory,
     private val cacheKeyFactory: CacheKeyFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/DecryptedHeaderFileDataSource.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/DecryptedHeaderFileDataSource.kt
@@ -5,6 +5,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import kotlin.math.max
 
+@Suppress("UnsafeOptInUsageError")
 internal class DecryptedHeaderFileDataSource(
     private val decryptedHeader: ByteArray,
     private val upstream: DataSource,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/DecryptedHeaderFileDataSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/DecryptedHeaderFileDataSourceFactory.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine.datasource
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.FileDataSource
 
+@Suppress("UnsafeOptInUsageError")
 internal class DecryptedHeaderFileDataSourceFactory(
     private val decryptedHeader: ByteArray,
     private val upstream: FileDataSource.Factory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/DecryptedHeaderFileDataSourceFactoryFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/datasource/DecryptedHeaderFileDataSourceFactoryFactory.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.playbackengine.datasource
 
 import androidx.media3.datasource.FileDataSource
 
+@Suppress("UnsafeOptInUsageError")
 internal class DecryptedHeaderFileDataSourceFactoryFactory(
     private val upstream: FileDataSource.Factory,
 ) {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/di/ExoPlayerPlaybackEngineModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/di/ExoPlayerPlaybackEngineModule.kt
@@ -136,10 +136,12 @@ internal object ExoPlayerPlaybackEngineModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun exoMediaDrmProvider() = FrameworkMediaDrm.DEFAULT_PROVIDER
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun versionedCdmCalculator(exoMediaDrmProvider: ExoMediaDrm.Provider) =
         VersionedCdm.Calculator(exoMediaDrmProvider)
 
@@ -154,11 +156,13 @@ internal object ExoPlayerPlaybackEngineModule {
 
     @Provides
     @Singleton
+    @Suppress("UnsafeOptInUsageError")
     fun provideDatabaseProvider(context: Context): DatabaseProvider =
         StandaloneDatabaseProvider(context)
 
     @Provides
     @Singleton
+    @Suppress("UnsafeOptInUsageError")
     fun cache(
         appSpecificCacheDir: File,
         databaseProvider: DatabaseProvider,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/dj/DateParser.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/dj/DateParser.kt
@@ -3,5 +3,6 @@ package com.tidal.sdk.player.playbackengine.dj
 import androidx.media3.common.util.Util
 
 internal class DateParser {
+    @Suppress("UnsafeOptInUsageError")
     fun parseXsDateTime(value: String) = Util.parseXsDateTime(value)
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmSessionManagerFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmSessionManagerFactory.kt
@@ -4,6 +4,7 @@ import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManager
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 
+@Suppress("UnsafeOptInUsageError")
 internal class DrmSessionManagerFactory(
     private val defaultDrmSessionManagerBuilder: DefaultDrmSessionManager.Builder,
     private val tidalMediaDrmCallbackFactory: TidalMediaDrmCallbackFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmSessionManagerProviderFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmSessionManagerProviderFactory.kt
@@ -5,6 +5,7 @@ import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 
 internal class DrmSessionManagerProviderFactory {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(drmSessionManager: DrmSessionManager) =
         DrmSessionManagerProvider { drmSessionManager }
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/MediaDrmCallbackExceptionFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/MediaDrmCallbackExceptionFactory.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.media3.datasource.DataSpec
 import androidx.media3.exoplayer.drm.MediaDrmCallbackException
 
+@Suppress("UnsafeOptInUsageError")
 internal class MediaDrmCallbackExceptionFactory {
 
     private val dataSpec = DataSpec.Builder().setUri(Uri.EMPTY).build()

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallback.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallback.kt
@@ -26,7 +26,7 @@ import okhttp3.RequestBody
  * @param[provisionRequestBody] The [RequestBody] to be used as body for the provisioning post
  * request.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "UnsafeOptInUsageError")
 internal class TidalMediaDrmCallback(
     private val streamingApiRepository: StreamingApiRepository,
     private val base64Codec: Base64Codec,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallbackFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallbackFactory.kt
@@ -14,6 +14,7 @@ internal class TidalMediaDrmCallbackFactory(
     private val okHttpClient: OkHttpClient,
 ) {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(playbackInfo: PlaybackInfo, mode: DrmMode, extras: Map<String, String?>?) =
         TidalMediaDrmCallback(
             streamingApiRepository,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/error/ErrorHandler.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/error/ErrorHandler.kt
@@ -38,7 +38,7 @@ internal class ErrorHandler(private val errorCodeFactory: ErrorCodeFactory) {
             else -> errorCodeFactory.createForOther(extra)
         }
 
-    @Suppress("ComplexMethod", "LongMethod")
+    @Suppress("ComplexMethod", "LongMethod", "UnsafeOptInUsageError")
     fun getErrorEvent(throwable: Throwable?, productType: ProductType? = null): Event.Error {
         var crawler: Throwable? = throwable
         var errorEvent: Lazy<Event.Error?>? = null
@@ -285,6 +285,7 @@ internal class ErrorHandler(private val errorCodeFactory: ErrorCodeFactory) {
         }
     }
 
+    @Suppress("UnsafeOptInUsageError")
     private fun Int?.toErrorCodeExtra() =
         when (this) {
             ExoPlaybackException.TYPE_SOURCE -> ErrorCodeFactory.Extra.PlayerSourceError

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/DashMediaSourceFactoryFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/DashMediaSourceFactoryFactory.kt
@@ -4,6 +4,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 
+@Suppress("UnsafeOptInUsageError")
 internal class DashMediaSourceFactoryFactory(
     private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
 ) {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/MediaSourcerer.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/MediaSourcerer.kt
@@ -20,6 +20,7 @@ import kotlin.properties.Delegates
  * @param[playbackInfoMediaSourceFactory] A [PlaybackInfoMediaSourceFactory] to create
  * [PlaybackInfoMediaSource]s from [ForwardingMediaProduct]s.
  */
+@Suppress("UnsafeOptInUsageError")
 internal class MediaSourcerer(
     private val exoPlayer: ExoPlayer,
     private val playbackInfoMediaSourceFactory: PlaybackInfoMediaSourceFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSource.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSource.kt
@@ -22,7 +22,7 @@ import java.io.IOException
  * A [CompositeMediaSource] that fetches Playback info with the help of a [PlaybackInfoLoadable],
  * and then creates a [MediaSource] with the help of a [PlaybackInfoLoadableLoaderCallback].
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "UnsafeOptInUsageError")
 internal class PlaybackInfoMediaSource(
     val forwardingMediaProduct: ForwardingMediaProduct<MediaProduct>,
     private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceFactory.kt
@@ -14,9 +14,11 @@ import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoad
 import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadableLoaderCallbackFactory
 import com.tidal.sdk.player.playbackengine.mediasource.streamingsession.StreamingSession
 
+@Suppress("UnsafeOptInUsageError")
 private const val DATA_TYPE = C.DATA_TYPE_MANIFEST
 private const val LOADER_THREAD_NAME_SUFFIX = "PlaybackInfoMediaSource"
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlaybackInfoMediaSourceFactory(
     private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
     private val playbackInfoLoadableFactory: PlaybackInfoLoadableFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerAuthHlsMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerAuthHlsMediaSourceFactory.kt
@@ -6,6 +6,7 @@ import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.MediaSource
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlayerAuthHlsMediaSourceFactory(
     private val hlsMediaSourceFactory: HlsMediaSource.Factory,
 ) {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerDashMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerDashMediaSourceFactory.kt
@@ -5,6 +5,7 @@ import androidx.media3.exoplayer.dash.DashMediaSource
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import com.tidal.sdk.player.playbackengine.dash.DashManifestFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlayerDashMediaSourceFactory(
     private val dashMediaSourceFactory: DashMediaSource.Factory,
     private val dashManifestFactory: DashManifestFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerDashOfflineMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerDashOfflineMediaSourceFactory.kt
@@ -15,6 +15,7 @@ internal class PlayerDashOfflineMediaSourceFactory(
     private val offlineDrmHelper: OfflineDrmHelper?,
 ) {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(
         mediaItem: MediaItem,
         encodedManifest: String,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerDecryptedHeaderProgressiveOfflineMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerDecryptedHeaderProgressiveOfflineMediaSourceFactory.kt
@@ -13,6 +13,7 @@ internal class PlayerDecryptedHeaderProgressiveOfflineMediaSourceFactory(
     private val btsManifestFactory: BtsManifestFactory,
 ) {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(
         mediaItem: MediaItem,
         encodedManifest: String,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerHlsMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerHlsMediaSourceFactory.kt
@@ -7,6 +7,7 @@ import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.MediaSource
 import com.tidal.sdk.player.playbackengine.emu.EmuManifestFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlayerHlsMediaSourceFactory(
     private val hlsMediaSourceFactory: HlsMediaSource.Factory,
     private val emuManifestFactory: EmuManifestFactory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerProgressiveMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerProgressiveMediaSourceFactory.kt
@@ -5,6 +5,7 @@ import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import com.tidal.sdk.player.playbackengine.bts.BtsManifestFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlayerProgressiveMediaSourceFactory(
     private val progressiveMediaSourceFactoryFactory: ProgressiveMediaSourceFactoryFactory,
     private val cacheDataSourceFactory: CacheDataSource.Factory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerProgressiveOfflineMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlayerProgressiveOfflineMediaSourceFactory.kt
@@ -12,6 +12,7 @@ internal class PlayerProgressiveOfflineMediaSourceFactory(
     private val offlineStorageProvider: OfflineStorageProvider?,
 ) {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(
         mediaItem: MediaItem,
         encodedManifest: String,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/ProgressiveMediaSourceFactoryFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/ProgressiveMediaSourceFactoryFactory.kt
@@ -5,6 +5,7 @@ import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.extractor.ExtractorsFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class ProgressiveMediaSourceFactoryFactory(
     private val extractorsFactory: ExtractorsFactory,
     private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadable.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadable.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.runBlocking
 /**
  * A [Loader.Loadable] that loads [PlaybackInfo] with the help of our streaming api.
  */
+@Suppress("UnsafeOptInUsageError")
 internal class PlaybackInfoLoadable(
     private val streamingSession: StreamingSession,
     private val forwardingMediaProduct: ForwardingMediaProduct<MediaProduct>,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallback.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallback.kt
@@ -12,7 +12,7 @@ import com.tidal.sdk.player.playbackengine.mediasource.TidalMediaSourceCreator
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import java.io.IOException
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "UnsafeOptInUsageError")
 internal class PlaybackInfoLoadableLoaderCallback(
     private val mediaItem: MediaItem,
     private val tidalMediaSourceCreator: TidalMediaSourceCreator,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallbackFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallbackFactory.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import com.tidal.sdk.player.playbackengine.mediasource.TidalMediaSourceCreator
 import java.io.IOException
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlaybackInfoLoadableLoaderCallbackFactory(
     private val tidalMediaSourceCreator: TidalMediaSourceCreator,
     private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/VersionedCdm.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/VersionedCdm.kt
@@ -13,6 +13,7 @@ internal class VersionedCdm private constructor(
     val version: String?,
 ) {
 
+    @Suppress("UnsafeOptInUsageError")
     class Calculator(exoMediaDrmProvider: ExoMediaDrm.Provider) {
 
         private val widevine by lazy(LazyThreadSafetyMode.NONE) {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/model/DelayedMediaProductTransition.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/model/DelayedMediaProductTransition.kt
@@ -9,7 +9,7 @@ import com.tidal.sdk.player.playbackengine.mediasource.streamingsession.Playback
 internal data class DelayedMediaProductTransition(
     val from: PlaybackInfoMediaSource,
     val to: PlaybackInfoMediaSource,
-    val eventTime: EventTime,
+    @Suppress("UnsafeOptInUsageError") val eventTime: EventTime,
     val invokedAtMillis: Long,
     val newPositionSeconds: Double,
 ) {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDataSourceFactoryHelper.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDataSourceFactoryHelper.kt
@@ -27,5 +27,6 @@ internal abstract class OfflineDataSourceFactoryHelper<T : DataSource.Factory>(
         internalDataSourceFactory ?: create(offlineCacheProvider!!.getInternal(path))
             .also { internalDataSourceFactory = it }
 
+    @Suppress("UnsafeOptInUsageError")
     abstract fun create(cache: Cache): T
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDrmHelper.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDrmHelper.kt
@@ -9,6 +9,7 @@ import com.tidal.sdk.player.commonandroid.Base64Codec
  */
 internal class OfflineDrmHelper(private val base64Codec: Base64Codec) {
 
+    @Suppress("UnsafeOptInUsageError")
     fun setOfflineLicense(offlineLicense: String, drmSessionManager: DrmSessionManager) {
         val decodedOfflineLicense = base64Codec.decode(offlineLicense.toByteArray(CHARSET))
         (drmSessionManager as? DefaultDrmSessionManager)?.setMode(

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflinePlayDataSourceFactoryHelper.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflinePlayDataSourceFactoryHelper.kt
@@ -16,5 +16,6 @@ internal class OfflinePlayDataSourceFactoryHelper(
     offlineCacheProvider: OfflineCacheProvider?,
 ) : OfflineDataSourceFactoryHelper<DataSource.Factory>(offlineCacheProvider) {
 
+    @Suppress("UnsafeOptInUsageError")
     override fun create(cache: Cache) = cacheKeyAesCipherDataSourceFactoryFactory.create(cache)
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflinePlayDrmDataSourceFactoryHelper.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflinePlayDrmDataSourceFactoryHelper.kt
@@ -11,6 +11,7 @@ import com.tidal.sdk.player.playbackengine.offline.cache.OfflineCacheProvider
  * @param[offlineCacheProvider] An instance of [OfflineCacheProvider]. Used to get the correct
  * [Cache] instance.
  */
+@Suppress("UnsafeOptInUsageError")
 internal class OfflinePlayDrmDataSourceFactoryHelper(
     private val cacheDataSourceFactory: CacheDataSource.Factory,
     offlineCacheProvider: OfflineCacheProvider?,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/StorageDataSource.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/StorageDataSource.kt
@@ -20,6 +20,7 @@ import androidx.media3.datasource.TransferListener
  * Note: If we don't set this as upstream, it will use the [DummyDataSource] which just sends a
  * default [IOException], but we want to control this and use our own [StorageException].
  */
+@Suppress("UnsafeOptInUsageError")
 internal class StorageDataSource : DataSource {
 
     class Factory(private val storageDataSource: StorageDataSource) : DataSource.Factory {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/cache/OfflineCacheProvider.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/cache/OfflineCacheProvider.kt
@@ -6,6 +6,7 @@ import androidx.media3.datasource.cache.Cache
  * Implement this to provide [Cache] instances for both internal and external storage used for
  * offline content.
  */
+@Suppress("UnsafeOptInUsageError")
 interface OfflineCacheProvider {
     fun getExternal(path: String): Cache
 

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/crypto/CacheKeyAesCipherDataSource.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/crypto/CacheKeyAesCipherDataSource.kt
@@ -16,6 +16,7 @@ import androidx.media3.datasource.cache.CacheKeyFactory
  * for caching or offlining this piece of content.
  * @param[aesCipherDataSource] An instance of [AesCipherDataSource].
  */
+@Suppress("UnsafeOptInUsageError")
 internal class CacheKeyAesCipherDataSource(
     private val cacheKeyFactory: CacheKeyFactory,
     private val aesCipherDataSource: AesCipherDataSource,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/crypto/CacheKeyAesCipherDataSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/crypto/CacheKeyAesCipherDataSourceFactory.kt
@@ -27,6 +27,7 @@ import androidx.media3.datasource.cache.CacheKeyFactory
  * [androidx.media3.datasource.cache.CacheDataSource.Factory], depending on if your
  * content has been cached or offlined.
  */
+@Suppress("UnsafeOptInUsageError")
 class CacheKeyAesCipherDataSourceFactory(
     private val cacheKeyFactory: CacheKeyFactory,
     private val secretKey: ByteArray,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/CacheProvider.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/CacheProvider.kt
@@ -19,5 +19,6 @@ sealed class CacheProvider private constructor() {
      * Use an external [Cache] instead of Player creating one of its own.
      * Reason for using this is to reuse a cache instance that is already in use.
      */
+    @Suppress("UnsafeOptInUsageError")
     data class External(val cache: Cache) : CacheProvider()
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/ExtendedExoPlayer.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/ExtendedExoPlayer.kt
@@ -23,7 +23,7 @@ import kotlin.properties.Delegates
  */
 internal class ExtendedExoPlayer(
     private val delegate: ExoPlayer,
-    private val loadControl: LoadControl,
+    @Suppress("UnsafeOptInUsageError") private val loadControl: LoadControl,
     private val mediaSourcerer: MediaSourcerer,
     private val extendedExoPlayerState: ExtendedExoPlayerState,
 ) : ExoPlayer by delegate {
@@ -62,6 +62,7 @@ internal class ExtendedExoPlayer(
     fun setNext(forwardingMediaProduct: ForwardingMediaProduct<MediaProduct>?) =
         mediaSourcerer.setNext(forwardingMediaProduct)
 
+    @Suppress("UnsafeOptInUsageError")
     fun shouldStartPlaybackAfterUserAction() = loadControl.shouldStartPlayback(
         C.msToUs(delegate.totalBufferedDuration),
         delegate.playbackParameters.speed,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/PlayerCache.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/PlayerCache.kt
@@ -7,6 +7,7 @@ import androidx.media3.datasource.cache.Cache
  * within. This is important because we should not e.g. release something that is provided from
  * the outside, because it might be in use in other places and will thus create problems.
  */
+@Suppress("UnsafeOptInUsageError")
 internal sealed class PlayerCache private constructor(val cache: Cache) {
 
     class Provided(cache: Cache) : PlayerCache(cache)

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ExtendedExoPlayerModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ExtendedExoPlayerModule.kt
@@ -30,15 +30,18 @@ internal object ExtendedExoPlayerModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun trackSelectionFactory(): ExoTrackSelection.Factory = AdaptiveTrackSelection.Factory()
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun trackSelector(context: Context, trackSelectionFactory: ExoTrackSelection.Factory):
         TrackSelector = DefaultTrackSelector(context, trackSelectionFactory)
 
     @Provides
     @ExtendedExoPlayerComponent.Scoped
+    @Suppress("UnsafeOptInUsageError")
     fun loadControl(bufferConfiguration: BufferConfiguration): LoadControl =
         bufferConfiguration.run {
             DefaultLoadControl.Builder()
@@ -58,6 +61,7 @@ internal object ExtendedExoPlayerModule {
 
     @Provides
     @ExtendedExoPlayerComponent.Scoped
+    @Suppress("UnsafeOptInUsageError")
     fun priorityTaskManager() = PriorityTaskManager()
 
     @Provides
@@ -69,6 +73,7 @@ internal object ExtendedExoPlayerModule {
 
     @Provides
     @ExtendedExoPlayerComponent.Scoped
+    @Suppress("UnsafeOptInUsageError")
     fun exoPlayer(
         context: Context,
         renderersFactory: RenderersFactory,
@@ -93,6 +98,7 @@ internal object ExtendedExoPlayerModule {
 
     @Provides
     @ExtendedExoPlayerComponent.Scoped
+    @Suppress("UnsafeOptInUsageError")
     fun extendedExoPlayer(
         exoPlayer: ExoPlayer,
         loadControl: LoadControl,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
@@ -126,19 +126,23 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun fileDataSourceFactory() = FileDataSource.Factory()
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun cacheKeyFactory(): CacheKeyFactory = DefaultCacheKeyFactory()
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun cacheDataSinkFactory(playerCache: PlayerCache) =
         CacheDataSink.Factory().setCache(playerCache.cache)
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun provideCacheDataSourceFactoryForOnline(
         playerCache: PlayerCache,
         @ExtendedExoPlayerComponent.Local
@@ -158,10 +162,12 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun extractorsFactory(): ExtractorsFactory = TidalExtractorsFactory()
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun progressiveMediaSourceFactoryFactory(
         extractorsFactory: ExtractorsFactory,
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
@@ -170,11 +176,13 @@ internal object MediaSourcererModule {
     @Provides
     @Reusable
     @Named("defaultLoadErrorHandlingPolicy")
+    @Suppress("UnsafeOptInUsageError")
     fun loadErrorHandlingPolicy(): LoadErrorHandlingPolicy =
         DefaultLoadErrorHandlingPolicy(MINIMUM_LOADABLE_RETRY_COUNT)
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     internal fun providePlayerLoadErrorHandlingPolicy(
         @Named("defaultLoadErrorHandlingPolicy")
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
@@ -182,6 +190,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun dashMediaSourceFactory(
         cacheDataSourceFactoryForOnline: CacheDataSource.Factory,
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
@@ -193,6 +202,7 @@ internal object MediaSourcererModule {
     @Provides
     @Reusable
     @ExtendedExoPlayerComponent.Local
+    @Suppress("UnsafeOptInUsageError")
     fun hlsMediaSourceFactory(
         @ExtendedExoPlayerComponent.Local
         okHttpDataSourceFactory: OkHttpDataSource.Factory,
@@ -205,6 +215,7 @@ internal object MediaSourcererModule {
     @Provides
     @Reusable
     @ExtendedExoPlayerComponent.LocalWithAuth
+    @Suppress("UnsafeOptInUsageError")
     fun authHlsMediaSourceFactory(
         @ExtendedExoPlayerComponent.LocalWithAuth
         okHttpDataSourceFactory: OkHttpDataSource.Factory,
@@ -234,6 +245,7 @@ internal object MediaSourcererModule {
     @Provides
     @Reusable
     @Named("cacheDataSourceFactoryForOfflinePlay")
+    @Suppress("UnsafeOptInUsageError")
     fun cacheDataSourceFactory(
         storageDataSourceFactory: StorageDataSource.Factory,
         cacheKeyFactory: CacheKeyFactory,
@@ -244,6 +256,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun cacheKeyAesCipherDataSourceFactoryFactory(
         @Named("cacheDataSourceFactoryForOfflinePlay")
         cacheDataSourceFactory: CacheDataSource.Factory,
@@ -267,6 +280,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun offlinePlayDrmDataSourceFactoryHelper(
         @Named("cacheDataSourceFactoryForOfflinePlay")
         cacheDataSourceFactory: CacheDataSource.Factory,
@@ -300,6 +314,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun decryptedHeaderFileDataSourceFactoryFactory(
         upstream: FileDataSource.Factory,
     ) = DecryptedHeaderFileDataSourceFactoryFactory(upstream)
@@ -320,10 +335,12 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun dashManifestParser(): ParsingLoadable.Parser<DashManifest> = DashManifestParser()
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun dashManifestMapper(
         base64Codec: Base64Codec,
         dashManifestParser: ParsingLoadable.Parser<DashManifest>,
@@ -331,6 +348,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun playerDashMediaSourceFactory(
         dashMediaSourceFactory: DashMediaSource.Factory,
         dashManifestFactory: DashManifestFactory,
@@ -338,6 +356,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun dashMediaSourceFactoryFactory(
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
     ) = DashMediaSourceFactoryFactory(loadErrorHandlingPolicy)
@@ -369,6 +388,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun playerHlsMediaSourceFactory(
         @ExtendedExoPlayerComponent.Local
         hlsMediaSourceFactory: HlsMediaSource.Factory,
@@ -377,6 +397,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun playerAuthHlsMediaSourceFactory(
         @ExtendedExoPlayerComponent.LocalWithAuth
         hlsMediaSourceFactory: HlsMediaSource.Factory,
@@ -384,6 +405,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun defaultDrmSessionManagerBuilder(
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
     ) = DefaultDrmSessionManager.Builder()
@@ -439,6 +461,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun drmSessionManagerFactory(
         defaultDrmSessionManagerBuilder: DefaultDrmSessionManager.Builder,
         tidalMediaDrmCallbackFactory: TidalMediaDrmCallbackFactory,
@@ -491,6 +514,7 @@ internal object MediaSourcererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun playbackInfoLoadableLoaderCallbackFactory(
         tidalMediaSourceCreator: TidalMediaSourceCreator,
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
@@ -499,7 +523,7 @@ internal object MediaSourcererModule {
     @Provides
     @Reusable
     fun playbackInfoMediaSourceFactory(
-        loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
+        @Suppress("UnsafeOptInUsageError") loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
         playbackInfoLoadableFactory: PlaybackInfoLoadableFactory,
         playbackInfoLoadableLoaderCallbackFactory: PlaybackInfoLoadableLoaderCallbackFactory,
     ) = PlaybackInfoMediaSourceFactory(

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ProgressiveModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ProgressiveModule.kt
@@ -13,6 +13,7 @@ internal object ProgressiveModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun playerProgressiveMediaSourceFactory(
         progressiveMediaSourceFactoryFactory: ProgressiveMediaSourceFactoryFactory,
         cacheDataSourceFactory: CacheDataSource.Factory,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/RendererModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/RendererModule.kt
@@ -36,10 +36,12 @@ internal object RendererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun audioCapabilities(context: Context) = AudioCapabilities.getCapabilities(context)
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun defaultAudioTrackBufferSizeProvider(
         bufferConfiguration: BufferConfiguration,
     ) = DefaultAudioTrackBufferSizeProvider.Builder()
@@ -57,6 +59,7 @@ internal object RendererModule {
 
     @Provides
     @ExtendedExoPlayerComponent.Scoped
+    @Suppress("UnsafeOptInUsageError")
     fun defaultAudioSink(
         audioCapabilities: AudioCapabilities,
         audioProcessors: Array<AudioProcessor>,
@@ -69,12 +72,13 @@ internal object RendererModule {
 
     @Provides
     @Reusable
+    @Suppress("UnsafeOptInUsageError")
     fun fallbackAudioRendererFactory(context: Context, defaultAudioSink: DefaultAudioSink) =
         FallbackAudioRendererFactory(context, defaultAudioSink)
 
     @Provides
     @Reusable
-    @Suppress("SpreadOperator")
+    @Suppress("SpreadOperator", "UnsafeOptInUsageError")
     fun renderersFactory(
         mediaCodecVideoRendererFactory: MediaCodecVideoRendererFactory,
         libflacAudioRendererFactory: LibflacAudioRendererFactory?,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/PlayerRenderersFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/PlayerRenderersFactory.kt
@@ -10,6 +10,7 @@ import com.tidal.sdk.player.playbackengine.player.renderer.audio.fallback.Fallba
 import com.tidal.sdk.player.playbackengine.player.renderer.audio.flac.LibflacAudioRendererFactory
 import com.tidal.sdk.player.playbackengine.player.renderer.video.MediaCodecVideoRendererFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class PlayerRenderersFactory(
     private val mediaCodecVideoRendererFactory: MediaCodecVideoRendererFactory,
     private val libflacAudioRendererFactory: LibflacAudioRendererFactory?,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/audio/AudioRendererFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/audio/AudioRendererFactory.kt
@@ -6,6 +6,7 @@ import androidx.media3.exoplayer.audio.AudioRendererEventListener
 
 interface AudioRendererFactory {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(
         eventHandler: Handler,
         audioRendererEventListener: AudioRendererEventListener,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/audio/fallback/FallbackAudioRendererFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/audio/fallback/FallbackAudioRendererFactory.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import com.tidal.sdk.player.playbackengine.player.renderer.audio.AudioRendererFactory
 
+@Suppress("UnsafeOptInUsageError")
 internal class FallbackAudioRendererFactory(
     private val context: Context,
     private val defaultAudioSink: DefaultAudioSink,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/audio/flac/LibflacAudioRendererFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/audio/flac/LibflacAudioRendererFactory.kt
@@ -7,6 +7,7 @@ import com.tidal.sdk.player.playbackengine.player.renderer.audio.AudioRendererFa
 
 internal class LibflacAudioRendererFactory : AudioRendererFactory {
 
+    @Suppress("UnsafeOptInUsageError")
     override fun create(
         eventHandler: Handler,
         audioRendererEventListener: AudioRendererEventListener,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/video/MediaCodecVideoRendererFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/video/MediaCodecVideoRendererFactory.kt
@@ -9,6 +9,7 @@ import androidx.media3.exoplayer.video.VideoRendererEventListener
 
 internal class MediaCodecVideoRendererFactory(private val context: Context) {
 
+    @Suppress("UnsafeOptInUsageError")
     fun create(
         eventHandler: Handler,
         videoRendererEventListener: VideoRendererEventListener,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/util/PlayerCacheExtensions.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/util/PlayerCacheExtensions.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.playbackengine.util
 
 import com.tidal.sdk.player.playbackengine.player.PlayerCache
 
+@Suppress("UnsafeOptInUsageError")
 internal fun PlayerCache.clear() {
     with(cache) {
         keys.forEach {


### PR DESCRIPTION
This update is required to fix a Dolby Atmos issue that was fixed in version 1.2.1.

Change log [here](https://github.com/androidx/media/releases/tag/1.2.0).

A lot of APIs are now marked as `@UnstableApi`. Do we prefer to suppress per-case as done in this PR or globally suppress them?