### PR TITLE
Update media3 version 1.2.1.1 [alt]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ retrofit = "2.11.0"
 room = "2.6.1"
 slf4j-api = "2.0.12"
 tickaroo = "0.8.13"
-tidal-androidx-media = "1.1.1.2"
+tidal-androidx-media = "1.2.1.1"
 plugins-tidal = "unspecified"
 
 [libraries]

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<lint>
+    <issue id="UnsafeOptInUsageError">
+        <option name="opt-in" value="androidx.media3.common.util.UnstableApi" />
+    </issue>
+</lint>


### PR DESCRIPTION
This update is required to fix a Dolby Atmos issue that was fixed in version 1.2.1.

Change log [here](https://github.com/androidx/media/releases/tag/1.2.0).