### PR TITLE
Change MediaProduct.extras type

### DIFF
--- a/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/BaseMediaProduct.kt
+++ b/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/BaseMediaProduct.kt
@@ -1,10 +1,9 @@
 package com.tidal.sdk.player.common.model
 
 interface BaseMediaProduct {
-
     val productType: ProductType
     val productId: String
     val sourceType: String?
     val sourceId: String?
-    val extras: Map<String, String?>?
+    val extras: Extras?
 }

--- a/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/Extra.kt
+++ b/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/Extra.kt
@@ -1,0 +1,15 @@
+package com.tidal.sdk.player.common.model
+
+typealias Extras = Map<String, Extra?>
+
+sealed interface Extra {
+    data class Bool(val value: Boolean) : Extra
+
+    data class Number(val value: kotlin.Number) : Extra
+
+    data class Text(val value: String) : Extra
+
+    data class CollectionList(val value: List<Extra>?) : Extra
+
+    data class CollectionMap(val value: Extras?) : Extra
+}

--- a/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/MediaProduct.kt
+++ b/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/MediaProduct.kt
@@ -17,6 +17,6 @@ data class MediaProduct(
     override val productId: String,
     override val sourceType: String? = null,
     override val sourceId: String? = null,
-    override val extras: Map<String, String?>? = null,
+    override val extras: Extras? = null,
     val referenceId: String? = null,
 ) : BaseMediaProduct

--- a/player/events/src/main/java/com/tidal/sdk/player/events/DefaultEventReporter.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/DefaultEventReporter.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.events
 
 import com.google.gson.Gson
 import com.tidal.sdk.eventproducer.EventSender
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.events.converter.EventFactory
 import com.tidal.sdk.player.events.model.Event
 import kotlinx.coroutines.CoroutineScope
@@ -27,7 +28,7 @@ internal class DefaultEventReporter(
      * Can be used to report events inheriting from [Event.Payload]. Extra event information not
      * defined in the payload type will be filled in automatically.
      */
-    override fun <T : Event.Payload> report(payload: T, extras: Map<String, String?>?) {
+    override fun <T : Event.Payload> report(payload: T, extras: Extras?) {
         @Suppress("UNCHECKED_CAST")
         val eventFactory = eventFactories[payload::class.java]!! as EventFactory<T>
         coroutineScope.launch {

--- a/player/events/src/main/java/com/tidal/sdk/player/events/EventReporter.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/EventReporter.kt
@@ -1,5 +1,6 @@
 package com.tidal.sdk.player.events
 
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.events.model.Event
 
 /**
@@ -7,5 +8,5 @@ import com.tidal.sdk.player.events.model.Event
  */
 interface EventReporter {
 
-    fun <T : Event.Payload> report(payload: T, extras: Map<String, String?>?)
+    fun <T : Event.Payload> report(payload: T, extras: Extras?)
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/AudioDownloadStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/AudioDownloadStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class AudioDownloadStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: AudioDownloadStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = audioDownloadStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/AudioPlaybackSessionEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/AudioPlaybackSessionEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class AudioPlaybackSessionEventFactory(
 
     override suspend fun invoke(
         payload: AudioPlaybackSession.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = audioPlaybackSessionFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/AudioPlaybackStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/AudioPlaybackStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class AudioPlaybackStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: AudioPlaybackStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = audioPlaybackStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/BroadcastPlaybackSessionEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/BroadcastPlaybackSessionEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class BroadcastPlaybackSessionEventFactory(
 
     override suspend fun invoke(
         payload: BroadcastPlaybackSession.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = broadcastPlaybackSessionFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/BroadcastPlaybackStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/BroadcastPlaybackStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class BroadcastPlaybackStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: BroadcastPlaybackStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = broadcastPlaybackStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/DrmLicenseFetchEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/DrmLicenseFetchEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -14,7 +15,7 @@ internal class DrmLicenseFetchEventFactory(
     private val drmLicenseFetchFactory: DrmLicenseFetch.Factory,
 ) : EventFactory<DrmLicenseFetch.Payload> {
 
-    override suspend fun invoke(payload: DrmLicenseFetch.Payload, extras: Map<String, String?>?) =
+    override suspend fun invoke(payload: DrmLicenseFetch.Payload, extras: Extras?) =
         drmLicenseFetchFactory.create(
             trueTimeWrapper.currentTimeMillis,
             uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/EventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/EventFactory.kt
@@ -1,7 +1,8 @@
 package com.tidal.sdk.player.events.converter
 
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.events.model.Event
 
 internal interface EventFactory<T : Event.Payload> {
-    suspend operator fun invoke(payload: T, extras: Map<String, String?>?): Event<out Event.Payload>
+    suspend operator fun invoke(payload: T, extras: Extras?): Event<out Event.Payload>
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/NotStartedPlaybackStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/NotStartedPlaybackStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class NotStartedPlaybackStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: NotStartedPlaybackStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = notStartedPlaybackStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/PlaybackInfoFetchEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/PlaybackInfoFetchEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -14,7 +15,7 @@ internal class PlaybackInfoFetchEventFactory(
     private val playbackInfoFetchFactory: PlaybackInfoFetch.Factory,
 ) : EventFactory<PlaybackInfoFetch.Payload> {
 
-    override suspend fun invoke(payload: PlaybackInfoFetch.Payload, extras: Map<String, String?>?) =
+    override suspend fun invoke(payload: PlaybackInfoFetch.Payload, extras: Extras?) =
         playbackInfoFetchFactory.create(
             trueTimeWrapper.currentTimeMillis,
             uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/StreamingSessionEndEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/StreamingSessionEndEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class StreamingSessionEndEventFactory(
 
     override suspend fun invoke(
         payload: StreamingSessionEnd.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = streamingSessionEndFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/StreamingSessionStartEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/StreamingSessionStartEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -17,7 +18,7 @@ internal class StreamingSessionStartEventFactory(
 
     override suspend fun invoke(
         payload: StreamingSessionStart.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = streamingSessionStartFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/UCPlaybackSessionEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/UCPlaybackSessionEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -14,7 +15,7 @@ internal class UCPlaybackSessionEventFactory(
     private val ucPlaybackSessionFactory: UCPlaybackSession.Factory,
 ) : EventFactory<UCPlaybackSession.Payload> {
 
-    override suspend fun invoke(payload: UCPlaybackSession.Payload, extras: Map<String, String?>?) =
+    override suspend fun invoke(payload: UCPlaybackSession.Payload, extras: Extras?) =
         ucPlaybackSessionFactory.create(
             trueTimeWrapper.currentTimeMillis,
             uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/UCPlaybackStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/UCPlaybackStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class UCPlaybackStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: UCPlaybackStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = ucPlaybackStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/VideoDownloadStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/VideoDownloadStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class VideoDownloadStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: VideoDownloadStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = videoDownloadStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/VideoPlaybackSessionEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/VideoPlaybackSessionEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class VideoPlaybackSessionEventFactory(
 
     override suspend fun invoke(
         payload: VideoPlaybackSession.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = videoPlaybackSessionFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/converter/VideoPlaybackStatisticsEventFactory.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/converter/VideoPlaybackStatisticsEventFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.converter
 
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.ClientSupplier
 import com.tidal.sdk.player.events.UserSupplier
@@ -16,7 +17,7 @@ internal class VideoPlaybackStatisticsEventFactory(
 
     override suspend fun invoke(
         payload: VideoPlaybackStatistics.Payload,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = videoPlaybackStatisticsFactory.create(
         trueTimeWrapper.currentTimeMillis,
         uuidWrapper.randomUUID,

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/AudioDownloadStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/AudioDownloadStatistics.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -17,7 +18,7 @@ internal data class AudioDownloadStatistics @AssistedInject constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : DownloadStatistics<AudioDownloadStatistics.Payload>() {
 
     @Keep
@@ -47,7 +48,7 @@ internal data class AudioDownloadStatistics @AssistedInject constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): AudioDownloadStatistics
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/AudioPlaybackSession.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/AudioPlaybackSession.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -18,7 +19,7 @@ data class AudioPlaybackSession @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackSession<AudioPlaybackSession.Payload>() {
 
     @Keep
@@ -54,7 +55,7 @@ data class AudioPlaybackSession @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): AudioPlaybackSession
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/AudioPlaybackStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/AudioPlaybackStatistics.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaStorage
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
@@ -18,7 +19,7 @@ data class AudioPlaybackStatistics @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackStatistics<AudioPlaybackStatistics.Payload>() {
 
     @Keep
@@ -56,7 +57,7 @@ data class AudioPlaybackStatistics @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): AudioPlaybackStatistics
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/BroadcastPlaybackSession.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/BroadcastPlaybackSession.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -18,7 +19,7 @@ data class BroadcastPlaybackSession @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackSession<BroadcastPlaybackSession.Payload>() {
 
     @Keep
@@ -54,7 +55,7 @@ data class BroadcastPlaybackSession @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): BroadcastPlaybackSession
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/BroadcastPlaybackStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/BroadcastPlaybackStatistics.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaStorage
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
@@ -18,7 +19,7 @@ data class BroadcastPlaybackStatistics @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackStatistics<BroadcastPlaybackStatistics.Payload>() {
 
     @Keep
@@ -56,7 +57,7 @@ data class BroadcastPlaybackStatistics @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): BroadcastPlaybackStatistics
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/DrmLicenseFetch.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/DrmLicenseFetch.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.model
 
 import androidx.annotation.Keep
+import com.tidal.sdk.player.common.model.Extras
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -14,7 +15,7 @@ data class DrmLicenseFetch @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : StreamingMetrics<DrmLicenseFetch.Payload>("drm_license_fetch") {
 
     @Keep
@@ -37,7 +38,7 @@ data class DrmLicenseFetch @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): DrmLicenseFetch
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/Event.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/Event.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.events.model
 import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import com.tidal.sdk.eventproducer.model.ConsentCategory
+import com.tidal.sdk.player.common.model.Extras
 import java.util.UUID
 
 @Suppress("UnusedPrivateMember")
@@ -17,7 +18,7 @@ sealed class Event<T : Event.Payload>(
     protected abstract val uuid: UUID
     protected abstract val user: User
     protected abstract val client: Client
-    protected abstract val extras: Map<String, String?>?
+    protected abstract val extras: Extras?
     abstract val payload: T
 
     val consentCategory: ConsentCategory

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/NotStartedPlaybackStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/NotStartedPlaybackStatistics.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.model
 
 import androidx.annotation.Keep
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -14,7 +15,7 @@ data class NotStartedPlaybackStatistics @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackStatistics<NotStartedPlaybackStatistics.Payload>() {
 
     @Keep
@@ -52,7 +53,7 @@ data class NotStartedPlaybackStatistics @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): NotStartedPlaybackStatistics
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/PlaybackInfoFetch.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/PlaybackInfoFetch.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.model
 
 import androidx.annotation.Keep
+import com.tidal.sdk.player.common.model.Extras
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -14,7 +15,7 @@ data class PlaybackInfoFetch @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : StreamingMetrics<PlaybackInfoFetch.Payload>("playback_info_fetch") {
 
     @Keep
@@ -37,7 +38,7 @@ data class PlaybackInfoFetch @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): PlaybackInfoFetch
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/StreamingSessionEnd.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/StreamingSessionEnd.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.events.model
 
 import androidx.annotation.Keep
+import com.tidal.sdk.player.common.model.Extras
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -14,7 +15,7 @@ data class StreamingSessionEnd @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : StreamingMetrics<StreamingSessionEnd.Payload>("streaming_session_end") {
 
     @Keep
@@ -31,7 +32,7 @@ data class StreamingSessionEnd @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): StreamingSessionEnd
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/StreamingSessionStart.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/StreamingSessionStart.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.events.model
 
 import androidx.annotation.Keep
 import androidx.annotation.Px
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -16,7 +17,7 @@ data class StreamingSessionStart @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: DecoratedPayload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : StreamingMetrics<StreamingSessionStart.DecoratedPayload>(
     name = "streaming_session_start",
 ) {
@@ -115,7 +116,7 @@ data class StreamingSessionStart @AssistedInject internal constructor(
             user: User,
             client: Client,
             decoratedPayload: DecoratedPayload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): StreamingSessionStart
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/UCPlaybackSession.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/UCPlaybackSession.kt
@@ -5,6 +5,7 @@ import com.google.gson.annotations.SerializedName
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -18,7 +19,7 @@ data class UCPlaybackSession @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackSession<UCPlaybackSession.Payload>() {
 
     @Keep
@@ -54,7 +55,7 @@ data class UCPlaybackSession @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): UCPlaybackSession
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/UCPlaybackStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/UCPlaybackStatistics.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaStorage
 import com.tidal.sdk.player.common.model.ProductType
 import dagger.assisted.Assisted
@@ -18,7 +19,7 @@ data class UCPlaybackStatistics @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackStatistics<UCPlaybackStatistics.Payload>() {
 
     @Keep
@@ -56,7 +57,7 @@ data class UCPlaybackStatistics @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): UCPlaybackStatistics
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/VideoDownloadStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/VideoDownloadStatistics.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.events.model
 import androidx.annotation.Keep
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import com.tidal.sdk.player.common.model.VideoQuality
 import dagger.assisted.Assisted
@@ -17,7 +18,7 @@ internal data class VideoDownloadStatistics @AssistedInject constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : DownloadStatistics<VideoDownloadStatistics.Payload>() {
 
     @Keep
@@ -47,7 +48,7 @@ internal data class VideoDownloadStatistics @AssistedInject constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): VideoDownloadStatistics
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/VideoPlaybackSession.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/VideoPlaybackSession.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.events.model
 import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import com.tidal.sdk.player.common.model.AssetPresentation
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import com.tidal.sdk.player.common.model.VideoQuality
 import dagger.assisted.Assisted
@@ -17,7 +18,7 @@ data class VideoPlaybackSession @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackSession<VideoPlaybackSession.Payload>() {
 
     @Keep
@@ -53,7 +54,7 @@ data class VideoPlaybackSession @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): VideoPlaybackSession
     }
 }

--- a/player/events/src/main/java/com/tidal/sdk/player/events/model/VideoPlaybackStatistics.kt
+++ b/player/events/src/main/java/com/tidal/sdk/player/events/model/VideoPlaybackStatistics.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.events.model
 
 import androidx.annotation.Keep
 import com.tidal.sdk.player.common.model.AssetPresentation
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaStorage
 import com.tidal.sdk.player.common.model.ProductType
 import com.tidal.sdk.player.common.model.StreamType
@@ -18,7 +19,7 @@ data class VideoPlaybackStatistics @AssistedInject internal constructor(
     @Assisted override val user: User,
     @Assisted override val client: Client,
     @Assisted override val payload: Payload,
-    @Assisted override val extras: Map<String, String?>?,
+    @Assisted override val extras: Extras?,
 ) : PlaybackStatistics<VideoPlaybackStatistics.Payload>() {
 
     @Keep
@@ -56,7 +57,7 @@ data class VideoPlaybackStatistics @AssistedInject internal constructor(
             user: User,
             client: Client,
             payload: Payload,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ): VideoPlaybackStatistics
     }
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine
 import androidx.media3.exoplayer.drm.MediaDrmCallbackException
 import com.tidal.sdk.player.common.ForwardingMediaProduct
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
@@ -56,7 +57,7 @@ internal class StreamingApiRepository(
     @SuppressWarnings("TooGenericExceptionCaught") // We rethrow it, so no issue
     suspend fun getDrmLicense(
         drmLicenseRequest: DrmLicenseRequest,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ): DrmLicense {
         val startTimestamp = trueTimeWrapper.currentTimeMillis
         var errorMessage: String? = null

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmSessionManagerFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmSessionManagerFactory.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.playbackengine.drm
 
 import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManager
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 
 internal class DrmSessionManagerFactory(
@@ -11,7 +12,7 @@ internal class DrmSessionManagerFactory(
 
     fun createDrmSessionManagerForOnlinePlay(
         playbackInfo: PlaybackInfo,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ): DrmSessionManager {
         if (playbackInfo.licenseSecurityToken.isNullOrEmpty()) {
             return DrmSessionManager.DRM_UNSUPPORTED
@@ -21,7 +22,7 @@ internal class DrmSessionManagerFactory(
 
     fun createDrmSessionManagerForOfflinePlay(
         playbackInfo: PlaybackInfo.Offline,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ): DrmSessionManager {
         if (playbackInfo.offlineLicense!!.isEmpty()) {
             return DrmSessionManager.DRM_UNSUPPORTED
@@ -32,7 +33,7 @@ internal class DrmSessionManagerFactory(
     private fun createDefaultDrmSessionManager(
         playbackInfo: PlaybackInfo,
         drmMode: DrmMode = DrmMode.Streaming,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ): DefaultDrmSessionManager {
         return defaultDrmSessionManagerBuilder
             .build(tidalMediaDrmCallbackFactory.create(playbackInfo, drmMode, extras))

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallback.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallback.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine.drm
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.drm.ExoMediaDrm
 import androidx.media3.exoplayer.drm.MediaDrmCallback
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.Base64Codec
 import com.tidal.sdk.player.playbackengine.StreamingApiRepository
 import com.tidal.sdk.player.streamingapi.drm.model.DrmLicenseRequest
@@ -35,7 +36,7 @@ internal class TidalMediaDrmCallback(
     private val okHttpClient: OkHttpClient,
     private val provisionRequestBuilder: Lazy<Request.Builder>,
     private val provisionRequestBody: Lazy<RequestBody>,
-    private val extras: Map<String, String?>?,
+    private val extras: Extras?,
 ) : MediaDrmCallback {
 
     override fun executeKeyRequest(uuid: UUID, request: ExoMediaDrm.KeyRequest): ByteArray {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallbackFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallbackFactory.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.playbackengine.drm
 
 import androidx.media3.common.util.Util
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.commonandroid.Base64Codec
 import com.tidal.sdk.player.playbackengine.StreamingApiRepository
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
@@ -14,7 +15,7 @@ internal class TidalMediaDrmCallbackFactory(
     private val okHttpClient: OkHttpClient,
 ) {
 
-    fun create(playbackInfo: PlaybackInfo, mode: DrmMode, extras: Map<String, String?>?) =
+    fun create(playbackInfo: PlaybackInfo, mode: DrmMode, extras: Extras?) =
         TidalMediaDrmCallback(
             streamingApiRepository,
             base64Codec,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSource.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSource.kt
@@ -12,6 +12,7 @@ import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy.LoadErrorInfo
 import androidx.media3.exoplayer.upstream.Loader
 import com.tidal.sdk.player.common.ForwardingMediaProduct
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaProduct
 import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadable
 import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadableLoaderCallbackFactory
@@ -34,7 +35,7 @@ internal class PlaybackInfoMediaSource(
     LoadErrorInfo,
     private val loader: Loader,
     private val loaderCallbackFactory: PlaybackInfoLoadableLoaderCallbackFactory,
-    private val extras: Map<String, String?>?,
+    private val extras: Extras?,
 ) : CompositeMediaSource<Void>() {
 
     val playbackInfo: PlaybackInfo? by loadable::playbackInfo

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/TidalMediaSourceCreator.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/TidalMediaSourceCreator.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.playbackengine.mediasource
 
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.source.MediaSource
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.playbackengine.drm.DrmSessionManagerFactory
 import com.tidal.sdk.player.playbackengine.drm.DrmSessionManagerProviderFactory
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.ManifestMimeType
@@ -21,13 +22,13 @@ internal class TidalMediaSourceCreator(
     private val playerDashOfflineMediaSourceFactory: PlayerDashOfflineMediaSourceFactory,
     private val drmSessionManagerFactory: DrmSessionManagerFactory,
     private val drmSessionManagerProviderFactory: DrmSessionManagerProviderFactory,
-) : (MediaItem, PlaybackInfo, Map<String, String?>?) -> MediaSource {
+) : (MediaItem, PlaybackInfo, Extras?) -> MediaSource {
 
     @Suppress("LongMethod")
     override fun invoke(
         mediaItem: MediaItem,
         playbackInfo: PlaybackInfo,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ): MediaSource {
         return if (playbackInfo is PlaybackInfo.Offline) {
             when (playbackInfo.manifestMimeType) {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallback.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallback.kt
@@ -8,6 +8,7 @@ import androidx.media3.exoplayer.source.MediaSourceEventListener
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy.LoadErrorInfo
 import androidx.media3.exoplayer.upstream.Loader
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.playbackengine.mediasource.TidalMediaSourceCreator
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import java.io.IOException
@@ -23,7 +24,7 @@ internal class PlaybackInfoLoadableLoaderCallback(
     private val loadErrorInfoF: (LoadEventInfo, error: IOException, errorCount: Int) ->
     LoadErrorInfo,
     private val prepareChildSourceF: (MediaSource) -> Unit,
-    private val extras: Map<String, String?>?,
+    private val extras: Extras?,
 ) : Loader.Callback<PlaybackInfoLoadable> {
 
     var selectedMediaSource: MediaSource? = null

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallbackFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallbackFactory.kt
@@ -5,6 +5,7 @@ import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.MediaSourceEventListener
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.playbackengine.mediasource.TidalMediaSourceCreator
 import java.io.IOException
 
@@ -22,7 +23,7 @@ internal class PlaybackInfoLoadableLoaderCallbackFactory(
         loadErrorInfoF: (LoadEventInfo, error: IOException, errorCount: Int) ->
         LoadErrorHandlingPolicy.LoadErrorInfo,
         prepareChildSourceF: (MediaSource) -> Unit,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = PlaybackInfoLoadableLoaderCallback(
         mediaItem,
         tidalMediaSourceCreator,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/PlaybackSession.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/PlaybackSession.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine.mediasource.streamingsession
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductQuality
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.events.model.PlaybackSession.Payload.Action
@@ -18,7 +19,7 @@ internal sealed class PlaybackSession {
     abstract val sourceType: String?
     abstract val sourceId: String?
     abstract val actions: MutableList<Action>
-    abstract val extras: Map<String, String?>?
+    abstract val extras: Extras?
 
     var startTimestamp = 0L
     var startAssetPosition by
@@ -36,7 +37,7 @@ internal sealed class PlaybackSession {
         override val actualQuality: AudioQuality,
         override val sourceType: String?,
         override val sourceId: String?,
-        override val extras: Map<String, String?>?,
+        override val extras: Extras?,
     ) : PlaybackSession() {
 
         override val actions = mutableListOf<Action>()
@@ -51,7 +52,7 @@ internal sealed class PlaybackSession {
         override val actualQuality: VideoQuality,
         override val sourceType: String?,
         override val sourceId: String?,
-        override val extras: Map<String, String?>?,
+        override val extras: Extras?,
     ) : PlaybackSession() {
 
         override val actions = mutableListOf<Action>()
@@ -65,7 +66,7 @@ internal sealed class PlaybackSession {
         override val actualQuality: AudioQuality,
         override val sourceType: String?,
         override val sourceId: String?,
-        override val extras: Map<String, String?>?,
+        override val extras: Extras?,
     ) : PlaybackSession() {
 
         override val actions = mutableListOf<Action>()
@@ -78,7 +79,7 @@ internal sealed class PlaybackSession {
         override val requestedProductId: String,
         override val sourceType: String?,
         override val sourceId: String?,
-        override val extras: Map<String, String?>?,
+        override val extras: Extras?,
     ) : PlaybackSession() {
 
         override val actualQuality = AudioQuality.LOW

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/PlaybackStatistics.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/PlaybackStatistics.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine.mediasource.streamingsession
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaStorage
 import com.tidal.sdk.player.common.model.ProductQuality
 import com.tidal.sdk.player.common.model.StreamType
@@ -15,7 +16,7 @@ internal sealed interface PlaybackStatistics {
 
     val streamingSessionId: UUID
     val adaptations: List<Adaptation>
-    val extras: Map<String, String?>?
+    val extras: Extras?
 
     operator fun plus(adaptation: Adaptation): PlaybackStatistics
 
@@ -37,7 +38,7 @@ internal sealed interface PlaybackStatistics {
         override val streamingSessionId: UUID,
         override val idealStartTimestampMs: IdealStartTimestampMs,
         override val adaptations: List<Adaptation>,
-        override val extras: Map<String, String?>?,
+        override val extras: Extras?,
     ) : PlaybackStatistics {
 
         override fun plus(adaptation: Adaptation) =
@@ -70,7 +71,7 @@ internal sealed interface PlaybackStatistics {
                 override val adaptations: List<Adaptation>,
                 val actualAudioMode: AudioMode,
                 override val mediaStorage: MediaStorage,
-                override val extras: Map<String, String?>?,
+                override val extras: Extras?,
             ) : Prepared {
 
                 override fun plus(adaptation: Adaptation) =
@@ -91,7 +92,7 @@ internal sealed interface PlaybackStatistics {
                 override val adaptations: List<Adaptation>,
                 val actualStreamType: StreamType,
                 override val mediaStorage: MediaStorage,
-                override val extras: Map<String, String?>?,
+                override val extras: Extras?,
             ) : Prepared {
 
                 override fun plus(adaptation: Adaptation) =
@@ -109,7 +110,7 @@ internal sealed interface PlaybackStatistics {
                 override val versionedCdm: VersionedCdm,
                 override val adaptations: List<Adaptation>,
                 override val mediaStorage: MediaStorage,
-                override val extras: Map<String, String?>?,
+                override val extras: Extras?,
             ) : Prepared {
 
                 override val actualQuality = AudioQuality.LOW
@@ -130,7 +131,7 @@ internal sealed interface PlaybackStatistics {
                 override val actualQuality: AudioQuality,
                 override val adaptations: List<Adaptation>,
                 override val mediaStorage: MediaStorage,
-                override val extras: Map<String, String?>?,
+                override val extras: Extras?,
             ) : Prepared {
 
                 override fun plus(adaptation: Adaptation) =

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/StreamingSession.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/StreamingSession.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.playbackengine.mediasource.streamingsession
 import com.tidal.sdk.player.common.Configuration
 import com.tidal.sdk.player.common.ForwardingMediaProduct
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.EventReporter
@@ -15,12 +16,12 @@ import java.util.UUID
 internal sealed class StreamingSession private constructor(
     val id: UUID,
     val configuration: Configuration,
-    val extras: Map<String, String?>?,
+    val extras: Extras?,
 ) {
 
     fun createUndeterminedPlaybackStatistics(
         idealStartTimestampMs: PlaybackStatistics.IdealStartTimestampMs,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = PlaybackStatistics.Undetermined(id, idealStartTimestampMs, emptyList(), extras)
 
     @Suppress("LongMethod")
@@ -94,10 +95,10 @@ internal sealed class StreamingSession private constructor(
         )
     }
 
-    class Explicit(id: UUID, configuration: Configuration, extras: Map<String, String?>?) :
+    class Explicit(id: UUID, configuration: Configuration, extras: Extras?) :
         StreamingSession(id, configuration, extras)
 
-    class Implicit(id: UUID, configuration: Configuration, extras: Map<String, String?>?) :
+    class Implicit(id: UUID, configuration: Configuration, extras: Extras?) :
         StreamingSession(id, configuration, extras)
 
     sealed class Creator<T : Factory> private constructor(
@@ -111,7 +112,7 @@ internal sealed class StreamingSession private constructor(
         fun createAndReportStart(
             sessionProductType: ProductType,
             sessionProductId: String,
-            extras: Map<String, String?>?,
+            extras: Extras?,
         ) = factory.create(extras).also {
             eventReporter.report(
                 StreamingSessionStart.Payload(
@@ -150,12 +151,12 @@ internal sealed class StreamingSession private constructor(
         protected val configuration: Configuration,
     ) {
 
-        abstract fun create(extras: Map<String, String?>?): StreamingSession
+        abstract fun create(extras: Extras?): StreamingSession
 
         class Explicit(uuidWrapper: UUIDWrapper, configuration: Configuration) :
             Factory(uuidWrapper, configuration) {
 
-            override fun create(extras: Map<String, String?>?): StreamingSession = Explicit(
+            override fun create(extras: Extras?): StreamingSession = Explicit(
                 uuidWrapper.randomUUID,
                 configuration,
                 extras,
@@ -165,7 +166,7 @@ internal sealed class StreamingSession private constructor(
         class Implicit(uuidWrapper: UUIDWrapper, configuration: Configuration) :
             Factory(uuidWrapper, configuration) {
 
-            override fun create(extras: Map<String, String?>?): StreamingSession = Implicit(
+            override fun create(extras: Extras?): StreamingSession = Implicit(
                 uuidWrapper.randomUUID,
                 configuration,
                 extras

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/UndeterminedPlaybackSessionResolver.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/streamingsession/UndeterminedPlaybackSessionResolver.kt
@@ -1,5 +1,6 @@
 package com.tidal.sdk.player.playbackengine.mediasource.streamingsession
 
+import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.MediaStorage
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 
@@ -11,7 +12,7 @@ internal class UndeterminedPlaybackSessionResolver(
     operator fun invoke(
         undetermined: PlaybackStatistics.Undetermined,
         playbackInfo: PlaybackInfo,
-        extras: Map<String, String?>?,
+        extras: Extras?,
     ) = with(undetermined) {
         when (playbackInfo) {
             is PlaybackInfo.Track ->

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerModule.kt
@@ -2,10 +2,13 @@ package com.tidal.sdk.player.di
 
 import android.content.Context
 import android.net.ConnectivityManager
+import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.tidal.sdk.player.common.UUIDWrapper
+import com.tidal.sdk.player.common.model.Extra
 import com.tidal.sdk.player.commonandroid.Base64Codec
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
+import com.tidal.sdk.player.serialization.ExtrasSerializationAdapter
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
@@ -20,7 +23,12 @@ internal object PlayerModule {
 
     @Provides
     @Reusable
-    fun gson() = GsonBuilder().disableHtmlEscaping().create()
+    fun gson(): Gson {
+        return GsonBuilder()
+            .disableHtmlEscaping()
+            .registerTypeHierarchyAdapter(Extra::class.java, ExtrasSerializationAdapter())
+            .create()
+    }
 
     @Provides
     @Reusable

--- a/player/src/main/kotlin/com/tidal/sdk/player/serialization/ExtrasSerializationAdapter.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/serialization/ExtrasSerializationAdapter.kt
@@ -1,0 +1,94 @@
+package com.tidal.sdk.player.serialization
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import com.tidal.sdk.player.common.model.Extra
+import java.lang.reflect.Type
+
+class ExtrasSerializationAdapter :
+    JsonSerializer<Extra>,
+    JsonDeserializer<Extra?> {
+
+    override fun serialize(
+        src: Extra?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?,
+    ): JsonElement {
+        return when (src) {
+            is Extra -> src.toJsonElement()
+            else -> JsonNull.INSTANCE
+        }
+    }
+
+    private fun Extra.toJsonElement(): JsonElement {
+        return when (this) {
+            is Extra.Bool -> JsonPrimitive(value)
+            is Extra.CollectionList -> toJsonArrayElement()
+            is Extra.CollectionMap -> toJsonObjectElement()
+            is Extra.Number -> JsonPrimitive(value)
+            is Extra.Text -> JsonPrimitive(value)
+        }
+    }
+
+    private fun Extra.CollectionMap.toJsonObjectElement(): JsonElement {
+        return value?.let {
+            JsonObject().apply {
+                it.forEach { (key, extra) ->
+                    add(key, extra?.toJsonElement())
+                }
+            }
+        } ?: JsonNull.INSTANCE
+    }
+
+    private fun Extra.CollectionList.toJsonArrayElement(): JsonElement {
+        return value?.let {
+            JsonArray(it.size).apply {
+                it.forEach { extra ->
+                    add(extra.toJsonElement())
+                }
+            }
+        } ?: JsonNull.INSTANCE
+    }
+
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?,
+    ): Extra? {
+        return json?.toExtra()
+    }
+
+    private fun JsonElement.toExtra(): Extra? {
+        return when (this) {
+            is JsonObject -> {
+                Extra.CollectionMap(
+                    entrySet().associate {
+                        Pair(it.key, it.value?.toExtra())
+                    },
+                )
+            }
+
+            is JsonArray -> {
+                Extra.CollectionList(mapNotNull { it.toExtra() })
+            }
+
+            is JsonPrimitive -> {
+                when {
+                    isBoolean -> Extra.Bool(asBoolean)
+                    isNumber -> Extra.Number(asNumber)
+                    isString -> Extra.Text(asString)
+                    else -> null
+                }
+            }
+
+            else -> null
+        }
+    }
+}

--- a/player/src/test/kotlin/com/tidal/sdk/player/serialization/ExtrasSerializationAdapterTest.kt
+++ b/player/src/test/kotlin/com/tidal/sdk/player/serialization/ExtrasSerializationAdapterTest.kt
@@ -1,0 +1,131 @@
+package com.tidal.sdk.player.serialization
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonPrimitive
+import com.tidal.sdk.player.common.model.Extra
+import com.tidal.sdk.player.common.model.Extra.Bool
+import com.tidal.sdk.player.common.model.Extra.CollectionList
+import com.tidal.sdk.player.common.model.Extra.CollectionMap
+import com.tidal.sdk.player.common.model.Extra.Text
+import com.tidal.sdk.player.common.model.Extras
+import org.junit.jupiter.api.Test
+
+internal class ExtrasSerializationAdapterTest {
+
+    private val gson = GsonBuilder()
+        .registerTypeHierarchyAdapter(Extra::class.java, ExtrasSerializationAdapter())
+        .disableHtmlEscaping()
+        .create()
+
+    private val sampleExtras = CollectionMap(
+        mapOf(
+            "boolean" to Bool(true),
+            "int" to number(1),
+            "float" to number(1.01f),
+            "double" to number(1.7976931348623157E308),
+            "text" to Text("textValue"),
+            "listNumber" to CollectionList(listOf(number(1), number(2), number(3))),
+            "listMix" to CollectionList(
+                listOf(
+                    number(1),
+                    Text("a"),
+                    Bool(false),
+                    CollectionList(listOf(Text("listValue"))),
+                    CollectionMap(mapOf("key1" to number(1), "key2" to Text("a"))),
+                ),
+            ),
+            "mapMix" to CollectionMap(
+                mapOf(
+                    "key2.1" to CollectionMap(
+                        mapOf(
+                            "key2.1.1" to Bool(true),
+                            "key2.1.2" to number(1),
+                            "key2.1.3" to Text("a"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private val sampleJson = """
+        {
+            "boolean":true,
+            "int":1,
+            "float":1.01,
+            "double":1.7976931348623157E308,
+            "text":"textValue",
+            "listNumber":[1,2,3],
+            "listMix":[1,"a",false,["listValue"],{"key1":1,"key2":"a"}],
+            "mapMix":{"key2.1":{"key2.1.1":true,"key2.1.2":1,"key2.1.3":"a"}}
+        }
+    """.lines().joinToString("") {
+        it.replace(" ", "")
+    }
+
+    /**
+     * This is done to fix number's quality check.
+     * Gson implements LazilyParsedNumber whose equality only works for the Number with same type.
+     * Hence this converts current numbers to "LazilyParsedNumber" and allows for quality check.
+     */
+    private fun number(number: Number): Extra.Number {
+        return Extra.Number(JsonPrimitive(number.toString()).asNumber)
+    }
+
+    data class ExtrasHolder(
+        val someOtherValue: String,
+        val extras: Extras?,
+    )
+
+    @Test
+    fun verifySerializationFromExtrasToJson() {
+        assertThat(gson.toJson(sampleExtras)).isEqualTo(sampleJson)
+    }
+
+    @Test
+    fun verifyDeserializationFromJsonToExtras() {
+        assertThat(gson.fromJson(sampleJson, Extra::class.java)).isEqualTo(sampleExtras)
+    }
+
+    @Test
+    fun verifySerializationFromExtrasHolderClassToJson() {
+        val extrasHolder = ExtrasHolder("otherValue", mapOf("extra1" to sampleExtras))
+        val expectedJson = """
+            {"someOtherValue":"otherValue","extras":{"extra1":$sampleJson}}
+        """.trimIndent()
+
+        assertThat(gson.toJson(extrasHolder)).isEqualTo(expectedJson)
+    }
+
+    @Test
+    fun verifyDeserializationFromJsonToExtrasHolderClass() {
+        val extrasHolder = ExtrasHolder("otherValue", mapOf("extra1" to sampleExtras))
+        val actualJson = """
+            {"someOtherValue":"otherValue","extras":{"extra1":$sampleJson}}
+        """.trimIndent()
+
+        assertThat(gson.fromJson(actualJson, ExtrasHolder::class.java)).isEqualTo(extrasHolder)
+    }
+
+    @Test
+    fun verifyNullExtrasIsNotSerialized() {
+        val extrasHolder = ExtrasHolder("otherValue", null)
+        val expectedJson = """
+            {"someOtherValue":"otherValue"}
+        """.trimIndent()
+
+        assertThat(gson.toJson(extrasHolder)).isEqualTo(expectedJson)
+    }
+
+    @Test
+    fun verifyNullDeserializationForExtras() {
+        val extrasHolder = ExtrasHolder("otherValue", null)
+        val actualJson = """
+            {"someOtherValue":"otherValue","extras":null}
+        """.trimIndent()
+
+        assertThat(gson.fromJson(actualJson, ExtrasHolder::class.java)).isEqualTo(extrasHolder)
+    }
+}


### PR DESCRIPTION
Changed from: Map<String, String?>?
Changed to: Map<String, Extra?>?.

Extra is defined as:
```
sealed interface Extra {
    data class Bool(val value: Boolean) : Extra
    data class Number(val value: kotlin.Number) : Extra
    data class Text(val value: String) : Extra
    data class CollectionList(val value: List<Extra>?) : Extra
    data class CollectionMap(val value: Map<String, Extra?>?) : Extra
}
```

This enables support for more dynamic types and not limited to map of String values.

To support conversion to and from JSON, custom `JsonSerializer` and `JsonDeserializer` for `Extra` are added.