### PR TITLE
Add workflow to generate API client code in tidalapi module

### DIFF
--- a/.github/workflows/regenerate_tidalapi_module.yml
+++ b/.github/workflows/regenerate_tidalapi_module.yml
@@ -94,7 +94,6 @@ jobs:
           commit_title="Add ${{ steps.check_changes.outputs.changed_file_count }} files via GitHub Actions"
           commit_body="Changed files:\n${{ steps.check_changes.outputs.changed_files }}"
           
-          git add .
           git commit -m "$commit_title"$'\n\n'"$commit_body"
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/regenerate_tidalapi_module.yml
+++ b/.github/workflows/regenerate_tidalapi_module.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get link to released openapi-generator fork .jar
         id: get_release

--- a/.github/workflows/regenerate_tidalapi_module.yml
+++ b/.github/workflows/regenerate_tidalapi_module.yml
@@ -1,0 +1,132 @@
+name: Regenerate TidalApi Code
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "The branch to PR against"
+        required: false
+        default: "main"
+env:
+  API_MODULE_DIR: tidalapi
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  openapi-code-generation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get link to released openapi-generator fork .jar
+        id: get_release
+        run: |
+          repo_owner="tidal-music"
+          repo_name="openapi-generator"
+          
+          curl -s -H -v "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/$repo_owner/$repo_name/releases/latest" > release_info.json
+          # Extract the download URL for the desired asset (example: 'my-asset.zip')
+          ASSET_URL=$(jq -r '.assets[] | select(.name == "openapi-generator-cli.jar") | .browser_download_url' release_info.json)
+          
+          echo "::set-output name=asset_url::$ASSET_URL"
+
+      - name: Download generator binary
+        env:
+          ASSET_URL: ${{ steps.get_release.outputs.asset_url }}
+        run: |
+          echo "Downloading from ${{ env.ASSET_URL }}"
+          curl -L -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/octet-stream" \
+            -o tidalapi/bin/openapi-generator-cli.jar \
+            "${{ env.ASSET_URL }}"
+
+      - name: Run the TidalAPI code generation
+        run: |
+          cd ${{ env.API_MODULE_DIR }}
+          chmod +x ./bin/openapi-generator-cli.jar
+          python ./bin/generate-api-files.py ./bin/generate-api-config.json
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+
+      - name: Check for changes
+        id: check_changes
+        env:
+          GENERATED_FOLDER_NAME: "tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated"
+        run: |
+          git add ./tidalapi
+          changes_in_generated=$(git status -s $GENERATED_FOLDER_NAME | sed 's/"//g')
+          echo "Changes in $GENERATED_FOLDER_NAME:"
+          echo "$changes_in_generated"
+          
+          if [ -n "$changes_in_generated" ]; then
+            changes_detected="true"
+            changed_file_count=$(echo "$changes_in_generated" | wc -l)
+          else
+            changes_detected="false"
+            changed_file_count=0
+          echo "No new changes found."
+          fi
+          
+          {
+            echo 'changed_files<<EOF'
+            echo "$changes_in_generated"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+          
+          echo "changes_detected=$changes_detected" >> $GITHUB_OUTPUT
+          echo "changed_file_count=$changed_file_count" >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        id: commit_changes
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        run: |
+          git config user.email "svc-github-tidal-music-tools@block.xyz"
+          git config user.name "TIDAL Music Tools"
+          timestamp=$(date +"%Y-%m-%d-%H-%M-%S")
+          branch_name="tidal-music-tools/Update-Tidal-Api-$timestamp"
+          git checkout -b $branch_name
+          
+          # Generate commit message with the number of changed files in the title and the list in the body
+          commit_title="Add ${{ steps.check_changes.outputs.changed_file_count }} files via GitHub Actions"
+          commit_body="Changed files:\n${{ steps.check_changes.outputs.changed_files }}"
+          
+          git add .
+          git commit -m "$commit_title"$'\n\n'"$commit_body"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+
+      - name: Push changes
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
+        run: |
+          git push --set-upstream origin "${{env.BRANCH_NAME}}"
+
+      - name: Create Pull Request via API
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGED_FILES: ${{ steps.check_changes.outputs.changed_files }}
+          CHANGED_FILE_COUNT: ${{ steps.check_changes.outputs.changed_file_count }}
+          BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
+        run: |
+          pr_title="Automatic Tidal API module update - ${{env.CHANGED_FILE_COUNT}} files changed"
+          pr_body="Changed files:\n\n${{ env.CHANGED_FILES }}"
+          pr_body=$(echo -e "$pr_body")
+          pr_data=$(jq -n --arg title "$pr_title" \
+                            --arg head "${{env.BRANCH_NAME}}" \
+                            --arg base "${{ inputs.target_branch }}" \
+                            --arg body "$pr_body" \
+                            '{title: $title, head: $head, base: $base, body: $body}')
+
+          echo $pr_data
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "$pr_data" \
+            https://api.github.com/repos/${{ github.repository }}/pulls

--- a/tidalapi/bin/generate-api-config.json
+++ b/tidalapi/bin/generate-api-config.json
@@ -12,10 +12,7 @@
     {
       "inputURL": "https://developer.tidal.com/apiref/api-specifications/api-public-user-content/tidal-user-content-openapi-3.0.json"
     }
-
   ],
   "output": "./tidal-api-joined.json",
-  "openapi_generator_path": "tbd"
-
-
+  "openapi_generator_path": "bin/openapi-generator-cli.jar"
 }

--- a/tidalapi/bin/generate-api-files.py
+++ b/tidalapi/bin/generate-api-files.py
@@ -173,7 +173,7 @@ def main():
     result = subprocess.run([
         "java", "-jar", source, "generate",
         "-i", temp_json,
-        "-g", "tidal-kotlin",
+        "-g", "kotlin",
         "-o", project_root,
         "-c", f"{project_root}/openapi-config/openapi-config.yml",
         "--global-property",
@@ -194,7 +194,6 @@ def main():
     remove_specific_line_from_files(f"{project_root}/src", target_line)
 
     logging.info("Generation complete and cleaned up.")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds the workflow to re-generate the API code in the `:tidalapi` module.

The workflow is (for now) manually triggered. A pull request created by it looks like [this](https://github.com/tidal-music/tidal-sdk-android/pull/132).

This workflow:
1. downloads the latest available release from our openapi fork
2. Runs the generator script to download and merge the schemas and feed them to the generator
3. If it finds changes creates a PR with them