### PR TITLE
Add periodic check for automatic api regenration

### DIFF
--- a/.github/actions/check-api-pr/action.yml
+++ b/.github/actions/check-api-pr/action.yml
@@ -1,0 +1,44 @@
+name: 'Check API PR'
+description: 'Checks for an existing API update PR and returns its details'
+outputs:
+  existing_pr:
+    description: 'Whether an existing PR was found (true/false)'
+    value: ${{ steps.check_pr.outputs.existing_pr }}
+  pr_number:
+    description: 'The PR number if found'
+    value: ${{ steps.check_pr.outputs.pr_number }}
+  pr_branch:
+    description: 'The branch name of the PR if found'
+    value: ${{ steps.check_pr.outputs.pr_branch }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for existing PR
+      id: check_pr
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # Search for open PRs that contain "Automatic Tidal API module update" in the title
+        pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
+        
+        existing_pr_number=$(echo "$pr_data" | jq -r '.[] | select(.title | contains("Automatic Tidal API module update")) | .number' | head -n 1)
+        
+        if [ -n "$existing_pr_number" ] && [ "$existing_pr_number" != "null" ]; then
+          echo "Found existing PR #$existing_pr_number"
+          echo "existing_pr=true" >> $GITHUB_OUTPUT
+          echo "pr_number=$existing_pr_number" >> $GITHUB_OUTPUT
+          
+          # Get the branch name from the PR
+          pr_details=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$existing_pr_number")
+          branch_name=$(echo "$pr_details" | jq -r '.head.ref')
+          echo "pr_branch=$branch_name" >> $GITHUB_OUTPUT
+          
+          echo "Will use branch: $branch_name"
+        else
+          echo "No existing PR found"
+          echo "existing_pr=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/check-tidalapi-spec.yml
+++ b/.github/workflows/check-tidalapi-spec.yml
@@ -19,31 +19,7 @@ jobs:
 
       - name: Check for existing PR
         id: check_pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Search for open PRs that contain "Automatic Tidal API module update" in the title
-          pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
-          
-          existing_pr_number=$(echo "$pr_data" | jq -r '.[] | select(.title | contains("Automatic Tidal API module update")) | .number' | head -n 1)
-          
-          if [ -n "$existing_pr_number" ] && [ "$existing_pr_number" != "null" ]; then
-            echo "Found existing PR #$existing_pr_number"
-            echo "existing_pr=true" >> $GITHUB_OUTPUT
-            echo "pr_number=$existing_pr_number" >> $GITHUB_OUTPUT
-            
-            # Get the branch name from the PR
-            pr_details=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/$existing_pr_number")
-            branch_name=$(echo "$pr_details" | jq -r '.head.ref')
-            echo "pr_branch=$branch_name" >> $GITHUB_OUTPUT
-            
-            echo "Will check against branch: $branch_name"
-          else
-            echo "No existing PR found, will check against main branch"
-            echo "existing_pr=false" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/check-api-pr
 
       - name: Checkout PR branch if exists
         if: steps.check_pr.outputs.existing_pr == 'true'

--- a/.github/workflows/check-tidalapi-spec.yml
+++ b/.github/workflows/check-tidalapi-spec.yml
@@ -7,12 +7,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   check-api-spec:
     runs-on: ubuntu-latest
+    outputs:
+      changes_found: ${{ steps.compare.outputs.changes_found }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -32,6 +35,9 @@ jobs:
         run: |
           mkdir -p /tmp/api-check
           curl -s https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json -o /tmp/api-check/latest-api.json
+          # Save the spec to a location that can be used by the regeneration workflow
+          mkdir -p tidalapi/bin/openapi_downloads
+          cp /tmp/api-check/latest-api.json tidalapi/bin/openapi_downloads/tidal-api-oas.json
       
       - name: Compare API specs
         id: compare
@@ -46,34 +52,36 @@ jobs:
             diff -u "tidalapi/bin/tidal-api.json" "/tmp/api-check/latest-api.json" || true
             echo "::endgroup::"
           fi
+          
+      - name: Upload API spec as artifact
+        if: steps.compare.outputs.changes_found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-spec
+          path: /tmp/api-check/latest-api.json
+          retention-days: 1
 
       - name: Output result
         run: |
           if [ "${{ steps.compare.outputs.changes_found }}" == "true" ]; then
             echo "Changes found - see diff above"
             if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
-                echo "Will trigger the regenerate-tidalapi-module workflow to update the existing PR"
+                echo "Updating the existing PR..."
             else
-              echo "Will trigger the regenerate-tidalapi-module workflow to create a new PR"
+              echo "Creating a new PR..."
             fi
           else
             echo "No Changes found"
           fi
-          
-      - name: Trigger tidalapi module code generator
-        if: steps.compare.outputs.changes_found == 'true'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // Use the PR branch if it exists, otherwise use the current ref
-            const ref = ${{ steps.check_pr.outputs.existing_pr == 'true' }} 
-              ? '${{ steps.check_pr.outputs.pr_branch }}'
-              : context.ref;
-              
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'regenerate-tidalapi-module.yml',
-              ref: ref
-            });
+
+  regenerate-api:
+    needs: check-api-spec
+    if: needs.check-api-spec.outputs.changes_found == 'true'
+    uses: ./.github/workflows/regenerate-tidalapi-module.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      use_downloaded_spec: "true"
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-tidalapi-spec.yml
+++ b/.github/workflows/check-tidalapi-spec.yml
@@ -1,0 +1,103 @@
+name: Check API Spec Changes
+
+on:
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  check-api-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check for existing PR
+        id: check_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Search for open PRs that contain "Automatic Tidal API module update" in the title
+          pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
+          
+          existing_pr_number=$(echo "$pr_data" | jq -r '.[] | select(.title | contains("Automatic Tidal API module update")) | .number' | head -n 1)
+          
+          if [ -n "$existing_pr_number" ] && [ "$existing_pr_number" != "null" ]; then
+            echo "Found existing PR #$existing_pr_number"
+            echo "existing_pr=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$existing_pr_number" >> $GITHUB_OUTPUT
+            
+            # Get the branch name from the PR
+            pr_details=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$existing_pr_number")
+            branch_name=$(echo "$pr_details" | jq -r '.head.ref')
+            echo "pr_branch=$branch_name" >> $GITHUB_OUTPUT
+            
+            echo "Will check against branch: $branch_name"
+          else
+            echo "No existing PR found, will check against main branch"
+            echo "existing_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout PR branch if exists
+        if: steps.check_pr.outputs.existing_pr == 'true'
+        run: |
+          git fetch origin ${{ steps.check_pr.outputs.pr_branch }}
+          git checkout ${{ steps.check_pr.outputs.pr_branch }}
+          echo "Using API spec from PR branch: ${{ steps.check_pr.outputs.pr_branch }}"
+
+      - name: Download latest API spec
+        run: |
+          mkdir -p /tmp/api-check
+          curl -s https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json -o /tmp/api-check/latest-api.json
+      
+      - name: Compare API specs
+        id: compare
+        run: |
+          if cmp -s "tidalapi/bin/tidal-api.json" "/tmp/api-check/latest-api.json"; then
+            echo "No changes found in the API specification"
+            echo "changes_found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes found in the API specification"
+            echo "changes_found=true" >> $GITHUB_OUTPUT
+            echo "::group::API Specification Diff"
+            diff -u "tidalapi/bin/tidal-api.json" "/tmp/api-check/latest-api.json" || true
+            echo "::endgroup::"
+          fi
+
+      - name: Output result
+        run: |
+          if [ "${{ steps.compare.outputs.changes_found }}" == "true" ]; then
+            echo "Changes found - see diff above"
+            if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+                echo "Will trigger the regenerate-tidalapi-module workflow to update the existing PR"
+            else
+              echo "Will trigger the regenerate-tidalapi-module workflow to create a new PR"
+            fi
+          else
+            echo "No Changes found"
+          fi
+          
+      - name: Trigger tidalapi module code generator
+        if: steps.compare.outputs.changes_found == 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Use the PR branch if it exists, otherwise use the current ref
+            const ref = ${{ steps.check_pr.outputs.existing_pr == 'true' }} 
+              ? '${{ steps.check_pr.outputs.pr_branch }}'
+              : context.ref;
+              
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'regenerate-tidalapi-module.yml',
+              ref: ref
+            });

--- a/.github/workflows/regenerate-tidalapi-module.yml
+++ b/.github/workflows/regenerate-tidalapi-module.yml
@@ -96,23 +96,7 @@ jobs:
       - name: Check for existing PR
         id: check_pr
         if: steps.check_changes.outputs.changes_detected == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Search for open PRs that contain "Automatic Tidal API module update" in the title
-          pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
-          
-          existing_pr_number=$(echo "$pr_data" | jq -r '.[] | select(.title | contains("Automatic Tidal API module update")) | .number' | head -n 1)
-          
-          if [ -n "$existing_pr_number" ] && [ "$existing_pr_number" != "null" ]; then
-            echo "Found existing PR #$existing_pr_number"
-            echo "existing_pr=true" >> $GITHUB_OUTPUT
-            echo "pr_number=$existing_pr_number" >> $GITHUB_OUTPUT
-          else
-            echo "No existing PR found"
-            echo "existing_pr=false" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/check-api-pr
 
       - name: Commit changes
         id: commit_changes
@@ -126,9 +110,7 @@ jobs:
           
           if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
             # Try to find the branch of the existing PR
-            pr_data=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.check_pr.outputs.pr_number }}")
-            branch_name=$(echo "$pr_data" | jq -r '.head.ref')
+            branch_name="${{ steps.check_pr.outputs.pr_branch }}"
             
             # Check if branch exists locally
             if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then

--- a/.github/workflows/regenerate-tidalapi-module.yml
+++ b/.github/workflows/regenerate-tidalapi-module.yml
@@ -7,6 +7,25 @@ on:
         description: "The branch to PR against"
         required: false
         default: "main"
+      use_downloaded_spec:
+        description: "Whether to use the already downloaded API spec"
+        required: false
+        default: "false"
+  workflow_call:
+    inputs:
+      target_branch:
+        description: "The branch to PR against"
+        type: string
+        required: false
+        default: "main"
+      use_downloaded_spec:
+        description: "Whether to use the already downloaded API spec"
+        type: string
+        required: false
+        default: "false"
+    secrets:
+      token:
+        required: true
 env:
   API_MODULE_DIR: tidalapi
 
@@ -20,6 +39,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download API spec artifact
+        if: inputs.use_downloaded_spec == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: api-spec
+          path: /tmp/api-check
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -38,7 +64,7 @@ jobs:
           repo_owner="tidal-music"
           repo_name="openapi-generator"
           
-          curl -s -H -v "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -s -H -v "Authorization: token ${{ secrets.token }}" \
             "https://api.github.com/repos/$repo_owner/$repo_name/releases/latest" > release_info.json
           # Extract the download URL for the desired asset
           ASSET_URL=$(jq -r '.assets[] | select(.name == "openapi-generator-cli.jar") | .browser_download_url' release_info.json)
@@ -50,7 +76,7 @@ jobs:
           ASSET_URL: ${{ steps.get_release.outputs.asset_url }}
         run: |
           echo "Downloading from ${{ env.ASSET_URL }}"
-          curl -L -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -L -H "Authorization: token ${{ secrets.token }}" \
             -H "Accept: application/octet-stream" \
             -o tidalapi/bin/openapi-generator-cli.jar \
             "${{ env.ASSET_URL }}"
@@ -63,7 +89,20 @@ jobs:
       - name: Generate TidalAPI code
         run: |
           cd ${{ env.API_MODULE_DIR }}/bin
-          ./generate-api.sh
+          
+          # Check if we should use the pre-downloaded spec
+          if [ "${{ inputs.use_downloaded_spec }}" == "true" ] && [ -f "/tmp/api-check/latest-api.json" ]; then
+            echo "Using pre-downloaded API spec"
+            # Create directory if it doesn't exist
+            mkdir -p openapi_downloads
+            # Copy the artifact to the expected location
+            cp /tmp/api-check/latest-api.json openapi_downloads/tidal-api-oas.json
+            # Use the local file parameter that's already supported by the script
+            ./generate-api.sh --local-file "$(pwd)/openapi_downloads/tidal-api-oas.json"
+          else
+            echo "Downloading API spec as part of generation"
+            ./generate-api.sh
+          fi
 
       - name: Check for changes
         id: check_changes
@@ -105,7 +144,7 @@ jobs:
           git config user.email "svc-github-tidal-music-tools@block.xyz"
           git config user.name "TIDAL Music Tools"
           
-          # Use a consistent branch name for API updates
+          # Use a consistent branch name for API updates, so we can edit the PR later
           standard_branch_name="tidal-music-tools/auto-update-tidal-api"
           
           if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
@@ -142,7 +181,7 @@ jobs:
       - name: Push changes
         if: steps.check_changes.outputs.changes_detected == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}
           BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
         run: |
           git push --set-upstream origin "${{env.BRANCH_NAME}}" --force
@@ -150,7 +189,7 @@ jobs:
       - name: Create or Update Pull Request
         if: steps.check_changes.outputs.changes_detected == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.token }}
           CHANGED_FILES: ${{ steps.check_changes.outputs.changed_files }}
           CHANGED_FILE_COUNT: ${{ steps.check_changes.outputs.changed_file_count }}
           BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}

--- a/.github/workflows/regenerate-tidalapi-module.yml
+++ b/.github/workflows/regenerate-tidalapi-module.yml
@@ -43,7 +43,7 @@ jobs:
           # Extract the download URL for the desired asset
           ASSET_URL=$(jq -r '.assets[] | select(.name == "openapi-generator-cli.jar") | .browser_download_url' release_info.json)
           
-          echo "::set-output name=asset_url::$ASSET_URL"
+          echo "asset_url=$ASSET_URL" >> $GITHUB_OUTPUT
 
       - name: Download generator binary
         env:
@@ -93,18 +93,65 @@ jobs:
           echo "changes_detected=$changes_detected" >> $GITHUB_OUTPUT
           echo "changed_file_count=$changed_file_count" >> $GITHUB_OUTPUT
 
+      - name: Check for existing PR
+        id: check_pr
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Search for open PRs that contain "Automatic Tidal API module update" in the title
+          pr_data=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open")
+          
+          existing_pr_number=$(echo "$pr_data" | jq -r '.[] | select(.title | contains("Automatic Tidal API module update")) | .number' | head -n 1)
+          
+          if [ -n "$existing_pr_number" ] && [ "$existing_pr_number" != "null" ]; then
+            echo "Found existing PR #$existing_pr_number"
+            echo "existing_pr=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$existing_pr_number" >> $GITHUB_OUTPUT
+          else
+            echo "No existing PR found"
+            echo "existing_pr=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit changes
         id: commit_changes
         if: steps.check_changes.outputs.changes_detected == 'true'
         run: |
           git config user.email "svc-github-tidal-music-tools@block.xyz"
           git config user.name "TIDAL Music Tools"
-          timestamp=$(date +"%Y-%m-%d-%H-%M-%S")
-          branch_name="tidal-music-tools/Update-Tidal-Api-$timestamp"
-          git checkout -b $branch_name
+          
+          # Use a consistent branch name for API updates
+          standard_branch_name="tidal-music-tools/auto-update-tidal-api"
+          
+          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+            # Try to find the branch of the existing PR
+            pr_data=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.check_pr.outputs.pr_number }}")
+            branch_name=$(echo "$pr_data" | jq -r '.head.ref')
+            
+            # Check if branch exists locally
+            if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+              git checkout "$branch_name"
+            else
+              # Try to fetch and checkout the branch
+              git fetch origin "$branch_name":"$branch_name" || true
+              if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+                git checkout "$branch_name"
+              else
+                # If branch doesn't exist, use the standard branch name
+                git checkout -b "$standard_branch_name"
+                branch_name="$standard_branch_name"
+              fi
+            fi
+          else
+            # Use standard branch name
+            git checkout -b "$standard_branch_name"
+            branch_name="$standard_branch_name"
+          fi
           
           # Generate commit message with the number of changed files in the title and the list in the body
-          commit_title="Add ${{ steps.check_changes.outputs.changed_file_count }} files via GitHub Actions"
+          commit_title="Update Tidal API - ${{ steps.check_changes.outputs.changed_file_count }} files changed"
           commit_body="Changed files:\n${{ steps.check_changes.outputs.changed_files }}"
           
           git commit -m "$commit_title"$'\n\n'"$commit_body"
@@ -116,9 +163,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
         run: |
-          git push --set-upstream origin "${{env.BRANCH_NAME}}"
+          git push --set-upstream origin "${{env.BRANCH_NAME}}" --force
 
-      - name: Create Pull Request via API
+      - name: Create or Update Pull Request
         if: steps.check_changes.outputs.changes_detected == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,18 +174,35 @@ jobs:
           BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
         run: |
           pr_title="Automatic Tidal API module update - ${{env.CHANGED_FILE_COUNT}} files changed"
-          pr_body="Changed files:\n\n${{ env.CHANGED_FILES }}"
+          pr_body="Changed files:\n\n${{ env.CHANGED_FILES }}\n\nAutomatically generated on $(date)\n\nThis PR is automatically updated when API changes are detected."
           pr_body=$(echo -e "$pr_body")
-          pr_data=$(jq -n --arg title "$pr_title" \
-                            --arg head "${{env.BRANCH_NAME}}" \
-                            --arg base "${{ inputs.target_branch }}" \
-                            --arg body "$pr_body" \
-                            '{title: $title, head: $head, base: $base, body: $body}')
-
-          echo $pr_data
-
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -d "$pr_data" \
-            https://api.github.com/repos/${{ github.repository }}/pulls
+          
+          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
+            # Update existing PR
+            pr_data=$(jq -n --arg title "$pr_title" \
+                              --arg body "$pr_body" \
+                              '{title: $title, body: $body}')
+            
+            curl -X PATCH \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "$pr_data" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.check_pr.outputs.pr_number }}"
+            
+            echo "Updated existing PR #${{ steps.check_pr.outputs.pr_number }}"
+          else
+            # Create new PR
+            pr_data=$(jq -n --arg title "$pr_title" \
+                              --arg head "${{env.BRANCH_NAME}}" \
+                              --arg base "${{ inputs.target_branch }}" \
+                              --arg body "$pr_body" \
+                              '{title: $title, head: $head, base: $base, body: $body}')
+            
+            curl -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "$pr_data" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls"
+            
+            echo "Created new PR"
+          fi


### PR DESCRIPTION
This change, once merged, will automatically run a check on the TOP API spec daily. If differences are found, it creates a PR. If a PR is already open, that PR gets updated.

Here is an example of the generated P:
https://github.com/tidal-music/tidal-sdk-android/pull/175

The workflows are fairly complex because they have to evaluate a number of things, while keeping the existing functionality. If you follow the names and comments through the workflow steps, they should be easy to understand though