### PR TITLE
Update fossa action

### DIFF
--- a/.github/workflows/fossa-scan.yml
+++ b/.github/workflows/fossa-scan.yml
@@ -20,12 +20,12 @@ jobs:
           distribution: temurin
 
       - name: "Run FOSSA Scan"
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac
         with:
           api-key: ${{secrets.fossaApiKey}}
 
       - name: "Run FOSSA Tests"
-        uses: fossas/fossa-action@v1.3.3
+        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac
         with:
           api-key: ${{secrets.fossaApiKey}}
           run-tests: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/fossa-scan.yml
     secrets:
       pat: ${{ secrets.PACKAGES_PAT }}
-      fossaApiKey: ${{ secrets.FOSSAAPIKEY }}
+      fossaApiKey: ${{ secrets.FOSSA_API_KEY_FULL }}
 
   trigger-changelogs-check:
     name: Trigger changelog files check


### PR DESCRIPTION
This updates FOSSA to the latest version,
and uses a different API key. This key has more rights, which allows FOSSA to display more comprehensive logs.