### PR TITLE
bump version 0.3.9

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2025-09-09
+### Changed
+- Generated api based on the documentation
+
 ## [0.3.8] - 2025-09-08
 ### Changed
 - Generated api based on the documentation

--- a/tidalapi/gradle.properties
+++ b/tidalapi/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=SDK module wrapping Tidal Open Api
-version=0.3.8
+version=0.3.9


### PR DESCRIPTION
### Commits in this PR
- Bump tidalapi to 0.3.9 (4d32a75f)