### PR TITLE
TDAPEX-113: Automatic releases to Maven II

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   expose-tag:
-    name: Expose Tag
+    name: Expose tag and version
     runs-on: ubuntu-latest
     outputs:
       module-tag: ${{ steps.expose-tag.outputs.tag }}
@@ -38,7 +38,8 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "tag=$tag" >> $GITHUB_OUTPUT
 
-  create-and-publish-release:
+  publish-to-gh-packages:
+    name: Publish packages to Github Packages
     runs-on: ubuntu-latest
     needs: [ expose-tag ]
     permissions: 
@@ -72,10 +73,10 @@ jobs:
         prerelease: false
         allowUpdates: false
 
-  publish-packages:
+  publish-to-maven-central:
     name: Publish packages to Maven Central
     runs-on: ubuntu-latest
-    needs: [ expose-tag, create-and-publish-release ]
+    needs: [ expose-tag ]
     permissions:
       contents: read
     env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,7 +61,7 @@ jobs:
         version_section=$(awk "/^## \[${{ env.version }}\]/{flag=1; next} /^## \[/{flag=0} flag" "$changelog_file")
         echo "$version_section" > /tmp/changelog_content.md
 
-    - name: Create and publish release
+    - name: Create and publish release to GH packages
       id: create-release
       uses: ncipollo/release-action@v1
       with:
@@ -71,3 +71,31 @@ jobs:
         draft: false
         prerelease: false
         allowUpdates: false
+
+  publish-packages:
+    name: Publish packages to Maven Central
+    runs-on: ubuntu-latest
+    needs: [ expose-tag, create-and-publish-release ]
+    permissions:
+      contents: read
+    env:
+      name: ${{ inputs.module}}
+      tag: ${{ needs.expose-tag.outputs.module-tag}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@b231772637bb498f11fdbc86052b6e8a8dc9fc92
+      - name: Publish package
+        run: |
+          ./gradlew publish-sdk-module-${{ env.name }} --continue
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_IN_MEMORY_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,39 +2,9 @@ name: Publish release
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - uses: gradle/actions/setup-gradle@v3
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@b231772637bb498f11fdbc86052b6e8a8dc9fc92
-      - name: Get module name
-        id: get-name
-        run: |
-          ref="${{ github.ref}}"
-          name="$( echo ${ref##*/} | cut -d- -f1 )"
-          echo "name=$name" >> $GITHUB_OUTPUT
-      - name: Publish package
-        run: |
-          ./gradlew publish-sdk-module-${{ env.NAME }} --continue
-        env:
-          NAME: ${{ steps.get-name.outputs.name }}
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_IN_MEMORY_KEY }}
-
   deploy-pages:
     name: Trigger GH Pages deployment
     if: startsWith(github.ref, 'refs/tags/bom-')

--- a/.github/workflows/trigger-deploy-pages.yml
+++ b/.github/workflows/trigger-deploy-pages.yml
@@ -1,4 +1,4 @@
-name: Publish release
+name: Trigger GH pages deploy
 
 on:
   release:

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ After confirming the name, a new directory will be created with the basic module
     ```
     Change `version` to the new value. This follows [Semantic Versioning](https://semver.org/). Also, you cannot downgrade - the CI/CD pipeline will refuse to work with downgrades.
 2. Each new release must have a changelog entry for the corresponding version code. So don't forget to add that too.
-3. Open a Pull Request with your version bump, get it approved and merge it. A release will be created for te changed module. It will be pushed to MavenCentral automatically. The release description will be pulled from the changelog.
+3. Open a Pull Request with your version bump, get it approved and merge it. A release will be created for te changed module. It will be pushed to GH packages and MavenCentral automatically. The release description will be pulled from the changelog.


### PR DESCRIPTION
I found out that automatically created releases do not trigger GH workflows, unlike manual ones. 
This means, automatically pushing to Maven after we created the release via a workflow on GH packages does not work the way I envisioned.

However, if it's automatic, we already decided that we we want a Maven release, so this can run in parallel. With this, the push to Maven is triggered at the same time as the one to GH packages - post-merge to main. No need for one to wait for the other