### PR TITLE
Fix unfollowArtist api method

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/apis/Artists.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/apis/Artists.kt
@@ -219,7 +219,7 @@ interface Artists {
      * @param artistFollowingRelationshipRemoveOperationPayload (optional)
      * @return [Unit]
      */
-    @DELETE("artists/{id}/relationships/following")
+    @HTTP(method = "DELETE", path = "artists/{id}/relationships/following", hasBody = true)
     suspend fun artistsIdRelationshipsFollowingDelete(
         @Path("id") id: kotlin.String,
         @Body


### PR DESCRIPTION
With the previous implementation I was getting the error:` Non-body HTTP method cannot contain @Body. `

[Thread on stackoverflow](https://stackoverflow.com/questions/41509195/how-to-send-a-http-delete-with-a-body-in-retrofit)
