### PR TITLE
Fix workflow push logic to handle existing remote branches

### DIFF
--- a/.github/workflows/regenerate-tidalapi-module.yml
+++ b/.github/workflows/regenerate-tidalapi-module.yml
@@ -199,12 +199,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
           BRANCH_NAME: ${{ steps.commit_changes.outputs.branch_name }}
         run: |
-          if [ "${{ steps.check_pr.outputs.existing_pr }}" == "true" ]; then
-            # Force push current state to existing PR branch
-            echo "Force pushing changes to existing PR branch: ${{env.BRANCH_NAME}}"
+          # Check if the remote branch exists
+          if git ls-remote --heads origin "${{env.BRANCH_NAME}}" | grep -q "${{env.BRANCH_NAME}}"; then
+            # Remote branch exists - force push to update it
+            echo "Remote branch exists. Force pushing changes to: ${{env.BRANCH_NAME}}"
             git push origin HEAD:"${{env.BRANCH_NAME}}" --force
           else
-            # Push new branch
+            # Remote branch doesn't exist - push new branch
             echo "Pushing new branch: ${{env.BRANCH_NAME}}"
             git push --set-upstream origin "${{env.BRANCH_NAME}}"
           fi


### PR DESCRIPTION
## Problem
The API regeneration workflow was failing with this error:


This happened because the workflow logic only checked for existing PRs to determine push strategy, but didn't account for cases where a remote branch exists without a matching open PR.

## Solution
Changed the push logic to check if the remote branch exists using `git ls-remote` and use force push when needed, regardless of PR existence status.

## Changes
- Updated push step to check remote branch existence directly
- Use force push when remote branch exists
- Use regular push for new branches

This ensures the workflow can handle all scenarios:
- New branch creation
- Updating existing branches (with or without open PRs)

Fixes the scheduled API check workflow failure.