### PR TITLE
Add simple music player app with TIDAL account integration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,3 +51,6 @@ includeFromDefaultHierarchy("common")
 includeFromDefaultHierarchy("eventproducer")
 
 includeFromDefaultHierarchy("tidalapi")
+
+// Simple Music Player - Your custom app!
+include("simple-player")

--- a/simple-player/README.md
+++ b/simple-player/README.md
@@ -1,0 +1,97 @@
+# Simple Music Player
+
+A simple, easy-to-use music player app that streams music from TIDAL using your account.
+
+## Features
+
+- 🎵 Stream music from TIDAL catalog
+- 🔐 Secure OAuth login with your TIDAL account
+- ▶️ Simple playback controls (Play/Pause)
+- 📱 Clean, modern Material Design 3 UI
+- 🎯 Play any track by entering its TIDAL ID
+
+## Quick Start
+
+**See [SETUP.md](SETUP.md) for complete setup instructions!**
+
+### TL;DR
+
+1. Get TIDAL API credentials from https://developer.tidal.com/
+2. Register redirect URI: `simplemusicplayer://auth/callback`
+3. Add credentials to `local.properties`:
+   ```properties
+   tidal.clientid=YOUR_CLIENT_ID
+   tidal.clientsecret=YOUR_CLIENT_SECRET
+   ```
+4. Run the app in Android Studio
+5. Login and play music!
+
+## How It Works
+
+This app demonstrates:
+- **TIDAL Auth SDK**: OAuth 2.0 authentication flow
+- **TIDAL Player SDK**: High-quality music streaming
+- **Deep Linking**: Handling OAuth redirect URIs
+- **Jetpack Compose**: Modern Android UI
+- **MVVM Architecture**: Clean separation of concerns
+
+## What is the Redirect URI?
+
+The **redirect URI** (`simplemusicplayer://auth/callback`) is where TIDAL sends users after they log in successfully.
+
+Think of it like this:
+1. Your app sends user to TIDAL's login page
+2. User logs in on TIDAL's website
+3. TIDAL redirects back to your app using this URI
+4. App receives the login confirmation
+5. User is logged in!
+
+The app is already configured to handle this URI - you just need to register it in your TIDAL Developer Portal.
+
+## Project Structure
+
+```
+simple-player/
+├── SETUP.md                    # Detailed setup guide (READ THIS FIRST!)
+├── README.md                   # This file
+├── build.gradle.kts           # Build configuration
+└── src/main/
+    ├── AndroidManifest.xml    # App manifest with deep link config
+    └── kotlin/com/simple/musicplayer/
+        ├── MusicPlayerApp.kt          # Application class
+        ├── MainActivity.kt            # Main UI
+        └── MusicPlayerViewModel.kt    # Business logic
+```
+
+## Requirements
+
+- Android Studio Hedgehog or newer
+- Android device/emulator with API 24+ (Android 7.0+)
+- TIDAL Developer account (free)
+- Active TIDAL subscription (for full-length playback)
+
+## Tech Stack
+
+- **Language**: Kotlin
+- **UI**: Jetpack Compose + Material Design 3
+- **Architecture**: MVVM with ViewModel
+- **Async**: Kotlin Coroutines + Flow
+- **Audio**: TIDAL Player SDK (ExoPlayer)
+- **Auth**: TIDAL Auth SDK (OAuth 2.0)
+
+## Need Help?
+
+Check [SETUP.md](SETUP.md) for:
+- Step-by-step setup instructions
+- Troubleshooting common issues
+- Understanding how OAuth works
+- Extending the app with new features
+
+## License
+
+This is a demonstration app built on top of the TIDAL Android SDK.
+See the main project LICENSE file for details.
+
+---
+
+**Ready to start? Open [SETUP.md](SETUP.md) and follow the steps!** 🚀

--- a/simple-player/SETUP.md
+++ b/simple-player/SETUP.md
@@ -1,0 +1,238 @@
+# Simple Music Player - Setup Guide
+
+This is a **simple music player app** that uses your TIDAL account to stream music. This guide will walk you through everything you need to get it running!
+
+## What You'll Be Able to Do
+
+- ✅ Login with your TIDAL account
+- ✅ Play any TIDAL track by entering its ID
+- ✅ Pause/resume playback
+- ✅ Stream high-quality music
+
+---
+
+## Step 1: Get TIDAL Developer Credentials
+
+### 1.1 Sign Up for TIDAL Developer Account
+
+1. Go to **[TIDAL Developer Platform](https://developer.tidal.com/)**
+2. Click **"Sign Up"** or **"Get Started"**
+3. Create a developer account (it's free!)
+
+### 1.2 Create an Application
+
+1. Once logged in, go to **"My Apps"** or **"Dashboard"**
+2. Click **"Create New App"** or **"New Application"**
+3. Fill in the details:
+   - **App Name**: "My Music Player" (or whatever you want)
+   - **Description**: "Personal music player app"
+
+### 1.3 Get Your Credentials
+
+After creating the app, you'll see:
+- **Client ID**: A long string like `a1b2c3d4e5f6`
+- **Client Secret**: Another long string (keep this private!)
+
+**IMPORTANT**: Copy both of these - you'll need them in the next step!
+
+### 1.4 Configure the Redirect URI
+
+This is the **most important part**:
+
+1. In your TIDAL app settings, find **"Redirect URIs"** or **"OAuth Redirect URIs"**
+2. Add this **EXACT** URI:
+   ```
+   simplemusicplayer://auth/callback
+   ```
+3. Save the changes
+
+**What is a Redirect URI?**
+- When you login, TIDAL's website will redirect you back to your app
+- This URI tells TIDAL where to send you after login
+- It's like your app's "return address"
+- The app is already configured to listen for this exact URI
+
+---
+
+## Step 2: Configure the App
+
+### 2.1 Create or Edit `local.properties`
+
+In the **root directory** of this project (same folder as `build.gradle.kts`), create or edit a file called `local.properties`.
+
+Add these lines (replace with YOUR credentials):
+
+```properties
+tidal.clientid=YOUR_CLIENT_ID_HERE
+tidal.clientsecret=YOUR_CLIENT_SECRET_HERE
+```
+
+**Example:**
+```properties
+tidal.clientid=a1b2c3d4e5f6g7h8i9j0
+tidal.clientsecret=z9y8x7w6v5u4t3s2r1q0p9o8n7m6
+```
+
+**⚠️ Important:**
+- Do NOT add quotes around the values
+- Do NOT commit this file to git (it's already in `.gitignore`)
+- Keep your client secret private!
+
+---
+
+## Step 3: Build and Run
+
+### 3.1 Open in Android Studio
+
+1. Open **Android Studio**
+2. Click **"Open"** and select this project folder
+3. Wait for Gradle sync to complete
+
+### 3.2 Run the App
+
+1. Connect an Android device or start an emulator
+2. In Android Studio, select **"simple-player"** from the run configuration dropdown
+3. Click the green **"Run"** button ▶️
+
+---
+
+## Step 4: Use the App
+
+### 4.1 First Time Login
+
+1. App opens and shows **"Login with TIDAL"** button
+2. Click the button
+3. Your browser opens with TIDAL's login page
+4. Enter your TIDAL username/password
+5. After successful login, you're automatically redirected back to the app
+6. You're now logged in!
+
+### 4.2 Play Music
+
+1. Find a TIDAL track ID:
+   - Go to https://listen.tidal.com
+   - Find any song
+   - Look at the URL: `https://listen.tidal.com/track/251380837`
+   - The number `251380837` is the track ID
+
+2. In the app:
+   - Enter the track ID in the text field
+   - Press **"Play"**
+   - Music starts playing! 🎵
+
+3. Controls:
+   - **Play**: Starts playing the entered track
+   - **Pause**: Pauses playback
+   - **Logout**: Logs you out
+
+---
+
+## Troubleshooting
+
+### ❌ "Missing TIDAL credentials" error
+**Solution**: Make sure you created `local.properties` in the **root** folder (not in `simple-player/`), and it contains your `tidal.clientid` and `tidal.clientsecret`.
+
+### ❌ Browser opens but nothing happens after login
+**Solution**:
+1. Make sure you added the EXACT redirect URI `simplemusicplayer://auth/callback` in your TIDAL Developer Portal
+2. Check that the URI has no typos or extra spaces
+3. Try uninstalling and reinstalling the app
+
+### ❌ "Player not initialized" error
+**Solution**: Make sure you're logged in first. The player only initializes after successful login.
+
+### ❌ Track won't play
+**Possible causes:**
+- Invalid track ID (check the number is correct)
+- Track not available in your region
+- You need an active TIDAL subscription for full playback (without subscription, you might only get 30-second previews)
+
+### ❌ App crashes on startup
+**Solution**: Check Android Studio's Logcat for error messages. Common issues:
+- Missing dependencies (run Gradle sync)
+- TrueTime initialization failed (usually fixes itself after a few seconds)
+
+---
+
+## Understanding the Code
+
+### Key Files:
+
+1. **`MainActivity.kt`**: The main screen and UI
+2. **`MusicPlayerViewModel.kt`**: Handles login and music playback logic
+3. **`MusicPlayerApp.kt`**: Initializes required libraries
+4. **`AndroidManifest.xml`**: Configures the redirect URI deep link
+
+### How Login Works:
+
+```
+1. User clicks "Login"
+   ↓
+2. App opens browser → TIDAL login page
+   ↓
+3. User enters credentials
+   ↓
+4. TIDAL validates and redirects to: simplemusicplayer://auth/callback?code=xyz
+   ↓
+5. Android opens your app (deep link)
+   ↓
+6. App exchanges code for access token
+   ↓
+7. User is logged in!
+```
+
+### The Redirect URI Explained:
+
+- **Format**: `simplemusicplayer://auth/callback`
+- **Parts**:
+  - `simplemusicplayer://` - Custom URL scheme (like `https://` but for your app)
+  - `auth/callback` - The path
+
+- **Configured in**: `AndroidManifest.xml` (lines 35-47)
+- **Used by**: TIDAL to redirect back to your app after login
+- **Must match**: The URI you registered in TIDAL Developer Portal
+
+---
+
+## What's Next?
+
+### Ideas to Extend This App:
+
+- Add a search function to find tracks
+- Create playlists
+- Show album artwork
+- Add volume controls
+- Display currently playing track info
+- Support albums and videos
+- Add a queue/playlist functionality
+
+### Customization:
+
+- Change the redirect URI:
+  1. Pick a new URI (e.g., `myawesomeapp://callback`)
+  2. Update in `build.gradle.kts` (line 27)
+  3. Update in `AndroidManifest.xml` (lines 43-46)
+  4. Update in TIDAL Developer Portal
+  5. Rebuild the app
+
+---
+
+## Need Help?
+
+- **TIDAL SDK Docs**: https://github.com/tidal-music/tidal-sdk-android
+- **TIDAL Developer Platform**: https://developer.tidal.com/
+- **Questions**: Check the main project README.md
+
+---
+
+## Summary
+
+✅ **You now have a fully functional music player!**
+
+**What you learned:**
+- OAuth authentication flow
+- How redirect URIs work
+- Using the TIDAL SDK
+- Building Android apps with Kotlin and Jetpack Compose
+
+**Enjoy your music!** 🎵🎶

--- a/simple-player/build.gradle.kts
+++ b/simple-player/build.gradle.kts
@@ -1,0 +1,85 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.simple.musicplayer"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.simple.musicplayer"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        // Load credentials from local.properties
+        val properties = org.jetbrains.kotlin.konan.properties.Properties()
+        val localPropertiesFile = rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            localPropertiesFile.inputStream().use { properties.load(it) }
+        }
+
+        buildConfigField("String", "TIDAL_CLIENT_ID", "\"${properties.getProperty("tidal.clientid", "")}\"")
+        buildConfigField("String", "TIDAL_CLIENT_SECRET", "\"${properties.getProperty("tidal.clientsecret", "")}\"")
+        buildConfigField("String", "TIDAL_REDIRECT_URI", "\"simplemusicplayer://auth/callback\"")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        buildConfig = true
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.8"
+    }
+}
+
+dependencies {
+    // TIDAL SDK
+    implementation(project(":auth"))
+    implementation(project(":player"))
+    implementation(project(":eventproducer"))
+
+    // Android Core
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+
+    // Compose
+    val composeBom = platform("androidx.compose:compose-bom:2024.01.00")
+    implementation(composeBom)
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-core")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.activity:activity-compose:1.8.2")
+
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    // TrueTime (required by TIDAL Player)
+    implementation("com.github.instacart:truetime-android:4.0.0.alpha")
+}

--- a/simple-player/proguard-rules.pro
+++ b/simple-player/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/simple-player/src/main/AndroidManifest.xml
+++ b/simple-player/src/main/AndroidManifest.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Permissions needed for music streaming -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application
+        android:name=".MusicPlayerApp"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+        android:usesCleartextTraffic="false">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+
+            <!-- Main launcher intent -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Deep link for OAuth redirect
+                 This is the REDIRECT URI: simplemusicplayer://auth/callback
+                 When TIDAL redirects here after login, Android opens your app -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- This matches: simplemusicplayer://auth/callback -->
+                <data
+                    android:scheme="simplemusicplayer"
+                    android:host="auth"
+                    android:path="/callback" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/simple-player/src/main/kotlin/com/simple/musicplayer/MainActivity.kt
+++ b/simple-player/src/main/kotlin/com/simple/musicplayer/MainActivity.kt
@@ -1,0 +1,283 @@
+package com.simple.musicplayer
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Main Activity - handles login and displays the music player
+ */
+class MainActivity : ComponentActivity() {
+
+    private val viewModel: MusicPlayerViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Initialize the ViewModel with this activity context
+        viewModel.initialize(this)
+
+        // Check if we're coming back from OAuth login
+        handleDeepLink(intent)
+
+        setContent {
+            MaterialTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    MusicPlayerScreen(viewModel)
+                }
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleDeepLink(intent)
+    }
+
+    /**
+     * Handle deep link from OAuth redirect
+     * When user logs in, TIDAL redirects to: simplemusicplayer://auth/callback?code=...
+     */
+    private fun handleDeepLink(intent: Intent?) {
+        val uri = intent?.data
+        if (uri != null && uri.toString().startsWith(BuildConfig.TIDAL_REDIRECT_URI)) {
+            Log.d("MainActivity", "Received OAuth redirect: $uri")
+            viewModel.handleLoginCallback(uri)
+        }
+    }
+}
+
+@Composable
+fun MusicPlayerScreen(viewModel: MusicPlayerViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Simple Music Player") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            when (uiState) {
+                is UiState.Loading -> {
+                    CircularProgressIndicator()
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text("Initializing...")
+                }
+
+                is UiState.NotLoggedIn -> {
+                    LoginScreen(
+                        onLoginClick = { viewModel.startLogin() },
+                        message = (uiState as UiState.NotLoggedIn).message
+                    )
+                }
+
+                is UiState.LoggedIn -> {
+                    PlayerScreen(
+                        viewModel = viewModel,
+                        state = uiState as UiState.LoggedIn
+                    )
+                }
+
+                is UiState.Error -> {
+                    ErrorScreen(
+                        error = (uiState as UiState.Error).message,
+                        onRetry = { viewModel.initialize(null) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun LoginScreen(onLoginClick: () -> Unit, message: String?) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = androidx.compose.material.icons.Icons.Default.MusicNote,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        Text(
+            text = "Welcome to Simple Music Player",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        if (message != null) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+
+        Button(
+            onClick = onLoginClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+        ) {
+            Text("Login with TIDAL")
+        }
+
+        Text(
+            text = "You need a TIDAL account to use this app",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+fun PlayerScreen(viewModel: MusicPlayerViewModel, state: UiState.LoggedIn) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        // User info
+        Card(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Logged In",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Ready to play music!",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+
+        // Track input
+        var trackId by remember { mutableStateOf("251380837") }
+        OutlinedTextField(
+            value = trackId,
+            onValueChange = { trackId = it },
+            label = { Text("TIDAL Track ID") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+
+        // Playback controls
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Button(
+                onClick = { viewModel.playTrack(trackId) },
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = androidx.compose.material.icons.Icons.Default.PlayArrow,
+                    contentDescription = "Play"
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Play")
+            }
+
+            Button(
+                onClick = { viewModel.pause() },
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = androidx.compose.material.icons.Icons.Default.Pause,
+                    contentDescription = "Pause"
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Pause")
+            }
+        }
+
+        // Status
+        if (state.currentStatus.isNotEmpty()) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                )
+            ) {
+                Text(
+                    text = state.currentStatus,
+                    modifier = Modifier.padding(16.dp),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+
+        // Logout button
+        Spacer(modifier = Modifier.weight(1f))
+        OutlinedButton(
+            onClick = { viewModel.logout() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Logout")
+        }
+    }
+}
+
+@Composable
+fun ErrorScreen(error: String, onRetry: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = androidx.compose.material.icons.Icons.Default.Error,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.error
+        )
+
+        Text(
+            text = "Error",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.error
+        )
+
+        Text(
+            text = error,
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        Button(onClick = onRetry) {
+            Text("Retry")
+        }
+    }
+}

--- a/simple-player/src/main/kotlin/com/simple/musicplayer/MusicPlayerApp.kt
+++ b/simple-player/src/main/kotlin/com/simple/musicplayer/MusicPlayerApp.kt
@@ -1,0 +1,29 @@
+package com.simple.musicplayer
+
+import android.app.Application
+import android.util.Log
+import com.instacart.library.truetime.TrueTime
+
+/**
+ * Application class that initializes required libraries
+ */
+class MusicPlayerApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // Initialize TrueTime (required by TIDAL SDK for accurate time syncing)
+        Thread {
+            try {
+                TrueTime()
+                    .withRootDelayMax(Float.MAX_VALUE)
+                    .withRootDispersionMax(Float.MAX_VALUE)
+                    .withServerResponseDelayMax(Int.MAX_VALUE)
+                    .initialize()
+                Log.d("MusicPlayerApp", "TrueTime initialized successfully")
+            } catch (e: Exception) {
+                Log.e("MusicPlayerApp", "TrueTime initialization failed", e)
+            }
+        }.start()
+    }
+}

--- a/simple-player/src/main/kotlin/com/simple/musicplayer/MusicPlayerViewModel.kt
+++ b/simple-player/src/main/kotlin/com/simple/musicplayer/MusicPlayerViewModel.kt
@@ -1,0 +1,320 @@
+package com.simple.musicplayer
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.auth.TidalAuth
+import com.tidal.sdk.auth.model.AuthConfig
+import com.tidal.sdk.auth.model.LoginConfig
+import com.tidal.sdk.eventproducer.EventProducer
+import com.tidal.sdk.eventproducer.model.EventsConfig
+import com.tidal.sdk.player.Player
+import com.tidal.sdk.player.common.model.MediaProduct
+import com.tidal.sdk.player.common.model.ProductType
+import com.tidal.sdk.player.playbackengine.model.Event
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * UI States for the app
+ */
+sealed class UiState {
+    object Loading : UiState()
+    data class NotLoggedIn(val message: String? = null) : UiState()
+    data class LoggedIn(val currentStatus: String = "") : UiState()
+    data class Error(val message: String) : UiState()
+}
+
+/**
+ * ViewModel that manages authentication and music playback
+ */
+class MusicPlayerViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    private var context: Context? = null
+    private var tidalAuth: TidalAuth? = null
+    private var credentialsProvider: CredentialsProvider? = null
+    private var player: Player? = null
+
+    private val TAG = "MusicPlayerViewModel"
+
+    /**
+     * Initialize the ViewModel with Android context
+     */
+    fun initialize(activityContext: Context?) {
+        activityContext?.let { context = it.applicationContext }
+
+        viewModelScope.launch {
+            try {
+                _uiState.value = UiState.Loading
+
+                // Check if credentials are configured
+                if (BuildConfig.TIDAL_CLIENT_ID.isEmpty() || BuildConfig.TIDAL_CLIENT_SECRET.isEmpty()) {
+                    _uiState.value = UiState.Error(
+                        "Missing TIDAL credentials. Please add them to local.properties file."
+                    )
+                    return@launch
+                }
+
+                // Initialize TIDAL Auth
+                initializeAuth()
+
+                // Check if user is already logged in
+                checkLoginStatus()
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Initialization error", e)
+                _uiState.value = UiState.Error("Initialization failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Initialize TIDAL Authentication
+     */
+    private fun initializeAuth() {
+        val ctx = context ?: return
+
+        tidalAuth = TidalAuth.getInstance(
+            AuthConfig(
+                clientId = BuildConfig.TIDAL_CLIENT_ID,
+                clientSecret = BuildConfig.TIDAL_CLIENT_SECRET,
+                scopes = setOf("r_usr", "w_usr"), // Read user data, write user data
+                credentialsKey = "com.simple.musicplayer",
+                enableCertificatePinning = false // Disable for easier development
+            ),
+            ctx
+        )
+
+        credentialsProvider = tidalAuth?.credentialsProvider
+        Log.d(TAG, "TIDAL Auth initialized")
+    }
+
+    /**
+     * Check if user is already logged in
+     */
+    private suspend fun checkLoginStatus() {
+        val provider = credentialsProvider ?: return
+
+        if (provider.isUserLoggedIn) {
+            // User is logged in, initialize player
+            initializePlayer()
+            _uiState.value = UiState.LoggedIn("Ready to play music")
+        } else {
+            _uiState.value = UiState.NotLoggedIn()
+        }
+    }
+
+    /**
+     * Start the OAuth login flow
+     * Opens browser/webview for user to login
+     */
+    fun startLogin() {
+        val auth = tidalAuth ?: return
+        val ctx = context ?: return
+
+        try {
+            // Get the login URL from TIDAL
+            val loginUri = auth.auth.initializeLogin(
+                BuildConfig.TIDAL_REDIRECT_URI,
+                LoginConfig()
+            )
+
+            Log.d(TAG, "Opening login URL: $loginUri")
+
+            // Open the login URL in the browser
+            val intent = Intent(Intent.ACTION_VIEW, loginUri).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+            ctx.startActivity(intent)
+
+            _uiState.value = UiState.NotLoggedIn("Opening browser for login...")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Login start failed", e)
+            _uiState.value = UiState.NotLoggedIn("Login failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Handle the callback from OAuth login
+     * Called when app receives the redirect URI: simplemusicplayer://auth/callback?code=...
+     */
+    fun handleLoginCallback(uri: Uri) {
+        val auth = tidalAuth ?: return
+
+        viewModelScope.launch {
+            try {
+                _uiState.value = UiState.Loading
+
+                Log.d(TAG, "Finalizing login with URI: $uri")
+
+                // Complete the login process
+                auth.auth.finalizeLogin(uri.toString())
+
+                // Initialize player now that we're logged in
+                initializePlayer()
+
+                _uiState.value = UiState.LoggedIn("Login successful!")
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Login finalization failed", e)
+                _uiState.value = UiState.NotLoggedIn("Login failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Initialize the TIDAL Player
+     */
+    private suspend fun initializePlayer() {
+        val ctx = context ?: return
+        val provider = credentialsProvider ?: return
+
+        try {
+            if (player != null) {
+                Log.d(TAG, "Player already initialized")
+                return
+            }
+
+            // Create Event Producer for analytics
+            val eventProducer = EventProducer(
+                credentialsProvider = provider,
+                config = EventsConfig()
+            )
+
+            // Create the Player
+            player = Player(
+                application = ctx as android.app.Application,
+                credentialsProvider = provider,
+                eventSender = eventProducer.eventSender
+            )
+
+            // Listen to player events
+            viewModelScope.launch {
+                player?.playbackEngine?.events?.collect { event ->
+                    handlePlayerEvent(event)
+                }
+            }
+
+            Log.d(TAG, "Player initialized successfully")
+
+        } catch (e: Exception) {
+            Log.e(TAG, "Player initialization failed", e)
+            _uiState.value = UiState.Error("Player init failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Play a TIDAL track by ID
+     */
+    fun playTrack(trackId: String) {
+        val playerEngine = player?.playbackEngine
+
+        if (playerEngine == null) {
+            updateStatus("Player not initialized")
+            return
+        }
+
+        if (trackId.isBlank()) {
+            updateStatus("Please enter a track ID")
+            return
+        }
+
+        viewModelScope.launch {
+            try {
+                updateStatus("Loading track $trackId...")
+
+                // Create a media product for the track
+                val mediaProduct = MediaProduct(
+                    productType = ProductType.TRACK,
+                    productId = trackId
+                )
+
+                // Load and play the track
+                playerEngine.load(mediaProduct)
+                playerEngine.play()
+
+                updateStatus("Playing track $trackId")
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Play track failed", e)
+                updateStatus("Error: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Pause playback
+     */
+    fun pause() {
+        player?.playbackEngine?.pause()
+        updateStatus("Paused")
+    }
+
+    /**
+     * Logout the user
+     */
+    fun logout() {
+        viewModelScope.launch {
+            try {
+                // Release player resources
+                player?.release()
+                player = null
+
+                // Logout from TIDAL
+                tidalAuth?.auth?.logout()
+
+                _uiState.value = UiState.NotLoggedIn("Logged out successfully")
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Logout failed", e)
+            }
+        }
+    }
+
+    /**
+     * Handle player events
+     */
+    private fun handlePlayerEvent(event: Event) {
+        Log.d(TAG, "Player Event: $event")
+
+        when (event) {
+            is Event.MediaProductTransition -> {
+                event.mediaProduct?.let {
+                    updateStatus("Now playing: ${it.productId}")
+                }
+            }
+            is Event.PlaybackStateChange -> {
+                updateStatus("Playback state: ${event.playbackState}")
+            }
+            else -> {
+                // Handle other events as needed
+            }
+        }
+    }
+
+    /**
+     * Update the status message in UI
+     */
+    private fun updateStatus(message: String) {
+        Log.d(TAG, "Status: $message")
+        val current = _uiState.value
+        if (current is UiState.LoggedIn) {
+            _uiState.value = current.copy(currentStatus = message)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        player?.release()
+    }
+}

--- a/simple-player/src/main/res/mipmap/ic_launcher.xml
+++ b/simple-player/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@android:color/white"/>
+    <foreground android:drawable="@android:drawable/ic_dialog_info"/>
+</adaptive-icon>

--- a/simple-player/src/main/res/mipmap/ic_launcher_round.xml
+++ b/simple-player/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@android:color/white"/>
+    <foreground android:drawable="@android:drawable/ic_dialog_info"/>
+</adaptive-icon>

--- a/simple-player/src/main/res/values/strings.xml
+++ b/simple-player/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Simple Music Player</string>
+</resources>


### PR DESCRIPTION
Created a simple, easy-to-use music player application that demonstrates how to use the TIDAL SDK to stream music with a user's TIDAL account.

Features:
- OAuth authentication with TIDAL accounts
- Deep link handling for OAuth redirect URI (simplemusicplayer://auth/callback)
- Simple Material Design 3 UI with Jetpack Compose
- Basic playback controls (play/pause)
- Play any TIDAL track by entering its ID

Key components:
- MainActivity.kt: Main UI and screen composables
- MusicPlayerViewModel.kt: Authentication and playback logic
- MusicPlayerApp.kt: Application initialization (TrueTime)
- AndroidManifest.xml: Deep link configuration for OAuth redirect
- Comprehensive SETUP.md guide explaining the entire setup process
- README.md with quick start instructions

The app includes detailed documentation explaining:
- How to get TIDAL developer credentials
- What a redirect URI is and how it works
- Step-by-step setup instructions
- Troubleshooting common issues
- How the OAuth flow works

This makes it easy for users to understand how to integrate TIDAL authentication and playback into their own Android applications.