### PR TITLE
Bump auth module version to 0.11.0

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2025-01-15
+### Changed
+- **BREAKING**: `finalizeLogin()` now expects only the query string component instead of the full redirect URL
+- Renamed internal `RedirectUri` type to `RedirectData` for clarity
+- Applied code formatting using ktfmt
+
+### Fixed
+- Updated OkHttp dependency to address FOSSA scan issue
+
 ## [0.10.2] - 2024-09-17
 ### Changed
 - Ensure that setting credentials manually is synced with retrieving them from the backend. This prevents accidental overwrites in local storage.

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Auth module manages app authentication, authorization, and token handling, simplifying OAuth processes, ensuring secure user access, and offering robust error handling.
-version=0.10.2
+version=0.11.0


### PR DESCRIPTION
## Summary
- Bumps auth module from version 0.10.2 to 0.11.0
- This is a minor version bump due to a breaking API change

## Changes
### Breaking Changes
- `finalizeLogin()` method now expects only the query string component instead of the full redirect URL
  - Previous: `finalizeLogin("https://example.com/redirect?code=abc&state=xyz")`
  - New: `finalizeLogin("code=abc&state=xyz")`

### Other Changes
- Internal type renamed from `RedirectUri` to `RedirectData` for clarity
- Code formatting applied using ktfmt
- OkHttp dependency updated to address FOSSA scan issue

## Testing
- [ ] Build succeeds
- [ ] Demo apps compile with updated auth module
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)