### PR TITLE
Fix LegacyCredentials deserialization crash (TM-1040)

### DIFF
--- a/.github/workflows/check-changelog-files.yml
+++ b/.github/workflows/check-changelog-files.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - run: mkdir workspace && cd workspace
       - uses: actions/checkout@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Expose tag and version
         id: expose-tag
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
 
     - name: Extract changelog content
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper

--- a/.github/workflows/fossa-scan.yml
+++ b/.github/workflows/fossa-scan.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: gradle/gradle-build-action@v3
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: "Run FOSSA Scan"

--- a/.github/workflows/instrumented-test.yml
+++ b/.github/workflows/instrumented-test.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-java@v4
         if: ${{ steps.detect_modules.outputs.run_tests == 'true' }}
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - uses: reactivecircus/android-emulator-runner@v2.33.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Run ktfmt
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Run detekt
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Run lint

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - run: mkdir workspace && cd workspace
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - run: ./gradlew bom:generateMetadataFileForMavenPublication
       - name: Extract module versions from BOM

--- a/.github/workflows/regenerate-tidalapi-module.yml
+++ b/.github/workflows/regenerate-tidalapi-module.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Get link to released openapi-generator fork .jar
         id: get_release

--- a/.github/workflows/tidalapi-validation.yml
+++ b/.github/workflows/tidalapi-validation.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Setup Gradle

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
 
       - name: Setup Gradle

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/storage/legacycredentials/CompatInstantSerializer.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/storage/legacycredentials/CompatInstantSerializer.kt
@@ -1,0 +1,30 @@
+package com.tidal.sdk.auth.storage.legacycredentials
+
+import kotlin.time.ExperimentalTime
+import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * A custom serializer for [Instant] that does not depend on
+ * `kotlinx.datetime.serializers.InstantIso8601Serializer`, which was removed in kotlinx-datetime
+ * 0.7.0. Uses the stable [Instant.parse] and [Instant.toString] APIs that are available across all
+ * kotlinx-datetime versions.
+ */
+@OptIn(ExperimentalTime::class)
+internal object CompatInstantSerializer : KSerializer<Instant> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): Instant {
+        return Instant.parse(decoder.decodeString())
+    }
+}

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/storage/legacycredentials/LegacyCredentials.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/storage/legacycredentials/LegacyCredentials.kt
@@ -1,8 +1,13 @@
+@file:UseSerializers(CompatInstantSerializer::class)
+@file:OptIn(ExperimentalTime::class)
+
 package com.tidal.sdk.auth.storage.legacycredentials
 
 import com.tidal.sdk.auth.model.Credentials
+import kotlin.time.ExperimentalTime
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 
 @Serializable
 sealed class LegacyCredentials {

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/storage/DefaultTokensStoreMigrationsTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/storage/DefaultTokensStoreMigrationsTest.kt
@@ -11,11 +11,13 @@ import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import kotlin.test.Test
+import kotlin.time.ExperimentalTime
 import kotlinx.datetime.Instant
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.BeforeEach
 
+@OptIn(ExperimentalTime::class)
 class DefaultTokensStoreMigrationsTest {
     private val testCredentialsKey = "testKey"
     private lateinit var sharedPreferences: SharedPreferences

--- a/auth/src/test/kotlin/com/tidal/sdk/auth/storage/legacycredentials/CompatInstantSerializerTest.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/auth/storage/legacycredentials/CompatInstantSerializerTest.kt
@@ -1,0 +1,123 @@
+package com.tidal.sdk.auth.storage.legacycredentials
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import kotlin.test.Test
+import kotlin.time.ExperimentalTime
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalTime::class)
+class CompatInstantSerializerTest {
+
+    @Test
+    fun `deserialize ISO 8601 string to Instant`() {
+        val json = Json
+        val result = json.decodeFromString(CompatInstantSerializer, "\"2024-03-15T10:30:00Z\"")
+        assertEquals(Instant.parse("2024-03-15T10:30:00Z"), result)
+    }
+
+    @Test
+    fun `serialize Instant to ISO 8601 string`() {
+        val json = Json
+        val instant = Instant.parse("2024-03-15T10:30:00Z")
+        val result = json.encodeToString(CompatInstantSerializer, instant)
+        assertEquals("\"2024-03-15T10:30:00Z\"", result)
+    }
+
+    @Test
+    fun `round-trip serialization preserves value`() {
+        val json = Json
+        val original = Instant.fromEpochSeconds(0)
+        val serialized = json.encodeToString(CompatInstantSerializer, original)
+        val deserialized = json.decodeFromString(CompatInstantSerializer, serialized)
+        assertEquals(original, deserialized)
+    }
+
+    @Test
+    fun `deserialize LegacyCredentialsV2 from hardcoded JSON with Instant field`() {
+        // This JSON simulates what kotlinx-datetime 0.5.0's InstantIso8601Serializer
+        // would have written to SharedPreferences. The test proves our custom serializer
+        // can read it without depending on the removed serializer class.
+        val storedJson =
+            """
+            {
+                "clientId": "testClient",
+                "requestedScopes": ["scope1"],
+                "clientUniqueKey": "key123",
+                "grantedScopes": ["scope1"],
+                "userId": "user1",
+                "expires": "1970-01-01T00:00:00Z",
+                "token": "testToken"
+            }
+        """
+                .trimIndent()
+
+        val result = Json.decodeFromString<LegacyCredentialsV2>(storedJson)
+
+        assertEquals("testClient", result.clientId)
+        assertEquals(Instant.fromEpochSeconds(0), result.expires)
+        assertEquals("testToken", result.token)
+    }
+
+    @Test
+    fun `deserialize LegacyCredentialsV2 with null expires`() {
+        val storedJson =
+            """
+            {
+                "clientId": "testClient",
+                "requestedScopes": ["scope1"],
+                "clientUniqueKey": null,
+                "grantedScopes": ["scope1"],
+                "userId": null,
+                "expires": null,
+                "token": "testToken"
+            }
+        """
+                .trimIndent()
+
+        val result = Json.decodeFromString<LegacyCredentialsV2>(storedJson)
+
+        assertNull(result.expires)
+    }
+
+    @Test
+    fun `deserialize LegacyCredentialsV1 from hardcoded JSON with Instant field`() {
+        val storedJson =
+            """
+            {
+                "clientId": "testClient",
+                "requestedScopes": {"scopes": ["scope1"]},
+                "clientUniqueKey": "key123",
+                "grantedScopes": {"scopes": ["scope1"]},
+                "userId": "user1",
+                "expires": "2024-12-31T23:59:59Z",
+                "token": "testToken"
+            }
+        """
+                .trimIndent()
+
+        val result = Json.decodeFromString<LegacyCredentialsV1>(storedJson)
+
+        assertEquals("testClient", result.clientId)
+        assertEquals(Instant.parse("2024-12-31T23:59:59Z"), result.expires)
+    }
+
+    @Test
+    fun `toCredentials converts Instant to epochSeconds`() {
+        val credentials =
+            LegacyCredentialsV2(
+                clientId = "testClient",
+                requestedScopes = setOf("scope1"),
+                clientUniqueKey = null,
+                grantedScopes = setOf("scope1"),
+                userId = null,
+                expires = Instant.fromEpochSeconds(1710499800),
+                token = "testToken",
+            )
+
+        val converted = credentials.toCredentials()
+
+        assertEquals(1710499800L, converted.expires)
+    }
+}

--- a/auth/src/test/kotlin/com/tidal/sdk/util/TestTimeProvider.kt
+++ b/auth/src/test/kotlin/com/tidal/sdk/util/TestTimeProvider.kt
@@ -4,11 +4,12 @@ import com.tidal.sdk.auth.util.TimeProvider
 import io.fluidsonic.time.ManualClock
 import io.fluidsonic.time.advance
 import kotlin.time.DurationUnit
+import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
-import kotlinx.datetime.Clock
 
+@OptIn(ExperimentalTime::class)
 class TestTimeProvider : TimeProvider {
-    val clock = ManualClock().apply { set(Clock.System.now()) }
+    val clock = ManualClock().apply { set(kotlin.time.Clock.System.now()) }
 
     override val now: Long
         get() = clock.now().epochSeconds

--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidApplicationConventionPlugin.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidApplicationConventionPlugin.kt
@@ -54,8 +54,8 @@ internal class KotlinAndroidApplicationConventionPlugin : Plugin<Project> {
             testOptions { execution = "ANDROIDX_TEST_ORCHESTRATOR" }
 
             compileOptions {
-                sourceCompatibility = JavaVersion.VERSION_17
-                targetCompatibility = JavaVersion.VERSION_17
+                sourceCompatibility = JavaVersion.VERSION_21
+                targetCompatibility = JavaVersion.VERSION_21
             }
 
             buildTypes { release { isMinifyEnabled = false } }

--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidLibraryConventionPlugin.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinAndroidLibraryConventionPlugin.kt
@@ -44,8 +44,8 @@ internal class KotlinAndroidLibraryConventionPlugin : Plugin<Project> {
             testOptions { execution = "ANDROIDX_TEST_ORCHESTRATOR" }
 
             compileOptions {
-                sourceCompatibility = JavaVersion.VERSION_17
-                targetCompatibility = JavaVersion.VERSION_17
+                sourceCompatibility = JavaVersion.VERSION_21
+                targetCompatibility = JavaVersion.VERSION_21
             }
 
             buildTypes { release { isMinifyEnabled = false } }

--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinJvmLibraryConventionPlugin.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/KotlinJvmLibraryConventionPlugin.kt
@@ -15,8 +15,8 @@ internal class KotlinJvmLibraryConventionPlugin : Plugin<Project> {
 
             // Configure Java compatibility
             extensions.configure<JavaPluginExtension> {
-                sourceCompatibility = JavaVersion.VERSION_17
-                targetCompatibility = JavaVersion.VERSION_17
+                sourceCompatibility = JavaVersion.VERSION_21
+                targetCompatibility = JavaVersion.VERSION_21
             }
 
             ConfiguresDokka()(this)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,7 @@ room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 
 # Serialization
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.5.0" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.7.1" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.6.3" }
 kotlinx-serialization-retrofit-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version = "1.0.0" }
 kotlinx-serialization-xml = { module = "io.github.pdvrieze.xmlutil:serialization", version = "0.86.2" }
@@ -92,7 +92,7 @@ test-androidx-junit = { module = "androidx.test.ext:junit", version = "1.1.5" }
 test-androidx-runner = { module = "androidx.test:runner", version = "1.5.2" }
 test-androidx-orchestrator = { module = "androidx.test:orchestrator", version = "1.4.2" }
 test-assertk = "com.willowtreeapps.assertk:assertk-jvm:0.28.0"
-test-fluidtime = { module = "io.fluidsonic.time:fluid-time", version = "0.18.0" }
+test-fluidtime = { module = "io.fluidsonic.time:fluid-time", version = "0.19.0" }
 test-junit5Api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 test-junit5Engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 test-junit5Params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }


### PR DESCRIPTION
## Summary

- Fix fatal crash during legacy credential migration caused by `InstantIso8601Serializer` removal in kotlinx-datetime 0.7.x
- Add custom `CompatInstantSerializer` using stable `Instant.parse`/`toString` APIs
- Bump kotlinx-datetime 0.5.0 → 0.7.1, fluid-time 0.18.0 → 0.19.0, Java target 17 → 21

## Context

Users upgrading to 2.186.0 with V2-format legacy credentials crash on startup with `ClassNotFoundException: kotlinx.datetime.serializers.InstantIso8601Serializer`. This is a login-blocking fatal crash.

**Linear:** [TM-1040](https://linear.app/squareup/issue/TM-1040)

## Test plan

- [x] `CompatInstantSerializerTest` verifies round-trip serialization and backward compatibility with JSON written by the old serializer
- [x] `DefaultTokensStoreMigrationsTest` verifies end-to-end V1 and V2 migration paths
- [ ] Manual: install older app version, log in, upgrade to build with this fix, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)