### PR TITLE
Ziad/player playbackinfo

### DIFF
--- a/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
@@ -83,6 +83,7 @@ class Player(
             )
     val configuration = playerComponent.configuration
     val playbackEngine = playerComponent.playbackEngine
+    val streamingApi = playerComponent.streamingApi
     private val streamingPrivileges = playerComponent.streamingPrivileges
 
     init {

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
@@ -10,6 +10,7 @@ import com.tidal.sdk.player.playbackengine.model.AssetTimeoutConfig
 import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
 import com.tidal.sdk.player.playbackengine.playbackprivilege.PlaybackPrivilegeProvider
 import com.tidal.sdk.player.playbackengine.player.CacheProvider
+import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.StreamingApiTimeoutConfig
 import com.tidal.sdk.player.streamingprivileges.StreamingPrivileges
 import dagger.BindsInstance
@@ -34,6 +35,7 @@ internal interface PlayerComponent {
 
     val configuration: Configuration
     val playbackEngine: PlaybackEngine
+    val streamingApi: StreamingApi
     val streamingPrivileges: StreamingPrivileges
 
     @Component.Factory


### PR DESCRIPTION
Exposing `streamingApi` through the player in order to utilise its playack info apis.