### PR TITLE
Fix StorageException for users with multi-path offline content

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDataSourceFactoryHelper.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDataSourceFactoryHelper.kt
@@ -16,20 +16,18 @@ internal abstract class OfflineDataSourceFactoryHelper<T : DataSource.Factory>(
     private val offlineCacheProvider: OfflineCacheProvider?
 ) {
 
-    private var externalDataSourceFactory: T? = null
-    private var internalDataSourceFactory: T? = null
+    private val externalDataSourceFactories = mutableMapOf<String, T>()
+    private val internalDataSourceFactories = mutableMapOf<String, T>()
 
-    fun getExternal(path: String) =
-        externalDataSourceFactory
-            ?: create(offlineCacheProvider!!.getExternal(path)).also {
-                externalDataSourceFactory = it
-            }
+    fun getExternal(path: String): T =
+        externalDataSourceFactories.getOrPut(path) {
+            create(checkNotNull(offlineCacheProvider).getExternal(path))
+        }
 
-    fun getInternal(path: String) =
-        internalDataSourceFactory
-            ?: create(offlineCacheProvider!!.getInternal(path)).also {
-                internalDataSourceFactory = it
-            }
+    fun getInternal(path: String): T =
+        internalDataSourceFactories.getOrPut(path) {
+            create(checkNotNull(offlineCacheProvider).getInternal(path))
+        }
 
     abstract fun create(cache: Cache): T
 }

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDataSourceFactoryHelperTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineDataSourceFactoryHelperTest.kt
@@ -1,0 +1,101 @@
+package com.tidal.sdk.player.playbackengine.offline
+
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.cache.Cache
+import assertk.assertThat
+import assertk.assertions.isSameInstanceAs
+import com.tidal.sdk.player.playbackengine.offline.cache.OfflineCacheProvider
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+
+internal class OfflineDataSourceFactoryHelperTest {
+
+    private val offlineCacheProvider = mock<OfflineCacheProvider>()
+    private val helper = TestOfflineDataSourceFactoryHelper(offlineCacheProvider)
+
+    @AfterEach fun afterEach() = verifyNoMoreInteractions(offlineCacheProvider)
+
+    @Test
+    fun getExternalMemoizesPerPath() {
+        val cacheA = mock<Cache>()
+        val cacheB = mock<Cache>()
+        whenever(offlineCacheProvider.getExternal("a")).thenReturn(cacheA)
+        whenever(offlineCacheProvider.getExternal("b")).thenReturn(cacheB)
+
+        val firstA = helper.getExternal("a")
+        val secondA = helper.getExternal("a")
+        val firstB = helper.getExternal("b")
+        val secondB = helper.getExternal("b")
+
+        assertThat(secondA).isSameInstanceAs(firstA)
+        assertThat(secondB).isSameInstanceAs(firstB)
+        assertThat(firstA.cache).isSameInstanceAs(cacheA)
+        assertThat(firstB.cache).isSameInstanceAs(cacheB)
+        verify(offlineCacheProvider).getExternal("a")
+        verify(offlineCacheProvider).getExternal("b")
+    }
+
+    @Test
+    fun getInternalMemoizesPerPath() {
+        val cacheA = mock<Cache>()
+        val cacheB = mock<Cache>()
+        whenever(offlineCacheProvider.getInternal("a")).thenReturn(cacheA)
+        whenever(offlineCacheProvider.getInternal("b")).thenReturn(cacheB)
+
+        val firstA = helper.getInternal("a")
+        val secondA = helper.getInternal("a")
+        val firstB = helper.getInternal("b")
+        val secondB = helper.getInternal("b")
+
+        assertThat(secondA).isSameInstanceAs(firstA)
+        assertThat(secondB).isSameInstanceAs(firstB)
+        assertThat(firstA.cache).isSameInstanceAs(cacheA)
+        assertThat(firstB.cache).isSameInstanceAs(cacheB)
+        verify(offlineCacheProvider).getInternal("a")
+        verify(offlineCacheProvider).getInternal("b")
+    }
+
+    @Test
+    fun internalAndExternalMapsAreIndependent() {
+        val externalCache = mock<Cache>()
+        val internalCache = mock<Cache>()
+        whenever(offlineCacheProvider.getExternal("p")).thenReturn(externalCache)
+        whenever(offlineCacheProvider.getInternal("p")).thenReturn(internalCache)
+
+        val external = helper.getExternal("p")
+        val internal = helper.getInternal("p")
+
+        assertThat(external.cache).isSameInstanceAs(externalCache)
+        assertThat(internal.cache).isSameInstanceAs(internalCache)
+        verify(offlineCacheProvider).getExternal("p")
+        verify(offlineCacheProvider).getInternal("p")
+    }
+
+    @Test
+    fun getExternalThrowsWhenProviderIsNull() {
+        val helperWithoutProvider = TestOfflineDataSourceFactoryHelper(null)
+
+        assertThrows<IllegalStateException> { helperWithoutProvider.getExternal("a") }
+    }
+
+    @Test
+    fun getInternalThrowsWhenProviderIsNull() {
+        val helperWithoutProvider = TestOfflineDataSourceFactoryHelper(null)
+
+        assertThrows<IllegalStateException> { helperWithoutProvider.getInternal("a") }
+    }
+
+    private class TestFactory(val cache: Cache) : DataSource.Factory {
+        override fun createDataSource(): DataSource = mock()
+    }
+
+    private class TestOfflineDataSourceFactoryHelper(offlineCacheProvider: OfflineCacheProvider?) :
+        OfflineDataSourceFactoryHelper<TestFactory>(offlineCacheProvider) {
+        override fun create(cache: Cache): TestFactory = TestFactory(cache)
+    }
+}


### PR DESCRIPTION
## Summary
- `OfflineDataSourceFactoryHelper.getExternal/getInternal` cached one factory per storage type and ignored the `path` argument after the first call. Because the helper is `@Reusable` in Dagger, that stale factory persisted for the whole app session, so users whose offline content lived at multiple paths within one storage class (e.g. they switched download location, hit an OS-level path migration, or use a different SD-card root) hit `StorageException` / `ERROR_CODE_IO_UNSPECIFIED` on later tracks at any path other than the first-seen one.
- Switch the per-storage-type field to a path-keyed `Map<String, T>` so each distinct path memoizes its own factory. Replace `!!` with `checkNotNull` on the nullable provider.
- Add `OfflineDataSourceFactoryHelperTest` (5 cases): per-path memoization for both `getExternal` and `getInternal`, independence of internal/external maps, and `IllegalStateException` when the provider is null.

## Test plan
- [x] `./gradlew :player:playback-engine:testDebugUnitTest` (full module suite passes locally on JBR 21)
- [x] New `OfflineDataSourceFactoryHelperTest` — all 5 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)