### PR TITLE
Ziad/player api endpoint arg

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ tidal-sdk-common = { module = "com.tidal.sdk:common", version = "0.2.5" }
 tidal-sdk-auth = { module = "com.tidal.sdk:auth", version = "0.10.1" }
 tidal-sdk-eventproducer = { module = "com.tidal.sdk:eventproducer", version = "0.3.2" }
 tidal-sdk-player = { module = "com.tidal.sdk:player", version = "0.0.39" }
-tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.31" }
+tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.33" }
 
 # Testing
 test-androidx-espresso-core = "androidx.test.espresso:espresso-core:3.5.1"

--- a/player/CHANGELOG.md
+++ b/player/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.64] - 2026-05-15
+### Changed
+- Update player to take in api endpoints.
+- Update streaming to use video manifest endpoint.
+
 ## [0.0.63] - 2026-03-31
 ### Changed
 - Update tidal api dependency.

--- a/player/common/src/main/kotlin/com/tidal/sdk/player/common/Common.kt
+++ b/player/common/src/main/kotlin/com/tidal/sdk/player/common/Common.kt
@@ -3,4 +3,5 @@ package com.tidal.sdk.player.common
 /** This is the entry point for Common functionality as described in the specs. */
 object Common {
     const val TIDAL_API_ENDPOINT_V1 = "https://api.tidal.com/v1/"
+    const val TIDAL_OPEN_API_ENDPOINT_V2 = "https://openapi.tidal.com/v2/"
 }

--- a/player/gradle.properties
+++ b/player/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Player module encapsulates the playback functionality of TIDAL media products.
-version=0.0.63
+version=0.0.64

--- a/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
+++ b/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
@@ -36,6 +36,7 @@ class PlayLogTestStreamingApiComponentFactory(private val trackPlaybackInfo: Pla
         credentialsProvider: CredentialsProvider,
         tidalApiCacheDir: File?,
         apiEndpoint: String,
+        openApiEndpoint: String,
     ): StreamingApiComponent {
         return object : StreamingApiComponent {
             override val streamingApi: StreamingApi = PlayLogTestStreamingApi(trackPlaybackInfo)

--- a/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
+++ b/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
@@ -35,6 +35,7 @@ class PlayLogTestStreamingApiComponentFactory(private val trackPlaybackInfo: Pla
         offlinePlaybackInfoProvider: OfflinePlaybackInfoProvider?,
         credentialsProvider: CredentialsProvider,
         tidalApiCacheDir: File?,
+        apiEndpoint: String,
     ): StreamingApiComponent {
         return object : StreamingApiComponent {
             override val streamingApi: StreamingApi = PlayLogTestStreamingApi(trackPlaybackInfo)

--- a/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
@@ -40,9 +40,12 @@ import okhttp3.OkHttpClient
  * @param[offlinePlayProvider] A means of supporting offline streaming when appropriate. Internal
  *   use only.
  * @param version The version of the app, used for event tracking. Defaults to 1.0.0.
- * @param apiEndpoint Base URL the player SDK targets for its own API calls (streaming-api and
+ * @param apiEndpoint Base URL the player SDK targets for its own API /v1 calls (streaming-api and
  *   streaming-privileges). Defaults to [Common.TIDAL_API_ENDPOINT_V1] (production). Override to
  *   point the player at a non-production environment, e.g. stage.
+ * @param openApiEndpoint Base URL the player SDK targets for OpenAPI /v2 calls. Defaults to
+ *   [Common.TIDAL_OPEN_API_ENDPOINT_V2] (production). Override to point at a non-production
+ *   environment, e.g. stage.
  */
 class Player(
     application: Application,
@@ -65,6 +68,7 @@ class Player(
     offlinePlayProvider: OfflinePlayProvider? = null,
     version: String = "1.0.0",
     apiEndpoint: String = Common.TIDAL_API_ENDPOINT_V1,
+    openApiEndpoint: String = Common.TIDAL_OPEN_API_ENDPOINT_V2,
 ) : ConfigurationListener {
     private val playerComponent =
         DaggerPlayerComponent.factory()
@@ -86,6 +90,7 @@ class Player(
                 playbackPrivilegeProvider,
                 offlinePlayProvider,
                 apiEndpoint,
+                openApiEndpoint,
             )
     val configuration = playerComponent.configuration
     val playbackEngine = playerComponent.playbackEngine

--- a/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player
 import android.app.Application
 import com.tidal.sdk.auth.CredentialsProvider
 import com.tidal.sdk.eventproducer.EventSender
+import com.tidal.sdk.player.common.Common
 import com.tidal.sdk.player.common.Configuration
 import com.tidal.sdk.player.common.ConfigurationListener
 import com.tidal.sdk.player.common.model.MediaProduct
@@ -39,6 +40,9 @@ import okhttp3.OkHttpClient
  * @param[offlinePlayProvider] A means of supporting offline streaming when appropriate. Internal
  *   use only.
  * @param version The version of the app, used for event tracking. Defaults to 1.0.0.
+ * @param apiEndpoint Base URL the player SDK targets for its own API calls (streaming-api and
+ *   streaming-privileges). Defaults to [Common.TIDAL_API_ENDPOINT_V1] (production). Override to
+ *   point the player at a non-production environment, e.g. stage.
  */
 class Player(
     application: Application,
@@ -60,6 +64,7 @@ class Player(
         },
     offlinePlayProvider: OfflinePlayProvider? = null,
     version: String = "1.0.0",
+    apiEndpoint: String = Common.TIDAL_API_ENDPOINT_V1,
 ) : ConfigurationListener {
     private val playerComponent =
         DaggerPlayerComponent.factory()
@@ -80,6 +85,7 @@ class Player(
                 isDebuggable,
                 playbackPrivilegeProvider,
                 offlinePlayProvider,
+                apiEndpoint,
             )
     val configuration = playerComponent.configuration
     val playbackEngine = playerComponent.playbackEngine

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/NetworkModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/NetworkModule.kt
@@ -7,7 +7,6 @@ import com.tidal.sdk.auth.model.Credentials
 import com.tidal.sdk.player.auth.AuthorizationInterceptor
 import com.tidal.sdk.player.auth.DefaultAuthenticator
 import com.tidal.sdk.player.auth.RequestAuthorizationDelegate
-import com.tidal.sdk.player.common.Common
 import com.tidal.sdk.player.interceptor.NonIntrusiveHttpLoggingInterceptor
 import dagger.Lazy
 import dagger.Module
@@ -42,8 +41,8 @@ internal object NetworkModule {
 
     @Provides
     @Reusable
-    fun endpointsRequiringCredentialLevels() =
-        mapOf("${Common.TIDAL_API_ENDPOINT_V1}rt/connect" to setOf(Credentials.Level.USER))
+    fun endpointsRequiringCredentialLevels(@Named("apiEndpoint") apiEndpoint: String) =
+        mapOf("${apiEndpoint}rt/connect" to setOf(Credentials.Level.USER))
 
     @Provides
     @Reusable

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
@@ -60,6 +60,7 @@ internal interface PlayerComponent {
             @BindsInstance playbackPrivilegeProvider: PlaybackPrivilegeProvider,
             @BindsInstance offlinePlayProvider: OfflinePlayProvider?,
             @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
+            @BindsInstance @Named("openApiEndpoint") openApiEndpoint: String,
         ): PlayerComponent
     }
 }

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
@@ -59,6 +59,7 @@ internal interface PlayerComponent {
             @BindsInstance @Named("isDebuggable") isDebuggable: Boolean,
             @BindsInstance playbackPrivilegeProvider: PlaybackPrivilegeProvider,
             @BindsInstance offlinePlayProvider: OfflinePlayProvider?,
+            @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
         ): PlayerComponent
     }
 }

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
@@ -37,6 +37,7 @@ internal object StreamingApiModule {
         offlinePlayProvider: OfflinePlayProvider?,
         credentialsProvider: CredentialsProvider,
         @Named("tidalApiCacheDir") tidalApiCacheDir: File,
+        @Named("apiEndpoint") apiEndpoint: String,
     ) =
         StreamingApiModuleRoot(
                 okHttpClient,
@@ -46,6 +47,7 @@ internal object StreamingApiModule {
                 offlinePlayProvider?.offlinePlaybackInfoProvider,
                 credentialsProvider,
                 tidalApiCacheDir,
+                apiEndpoint,
             )
             .streamingApi
 }

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
@@ -38,6 +38,7 @@ internal object StreamingApiModule {
         credentialsProvider: CredentialsProvider,
         @Named("tidalApiCacheDir") tidalApiCacheDir: File,
         @Named("apiEndpoint") apiEndpoint: String,
+        @Named("openApiEndpoint") openApiEndpoint: String,
     ) =
         StreamingApiModuleRoot(
                 okHttpClient,
@@ -48,6 +49,7 @@ internal object StreamingApiModule {
                 credentialsProvider,
                 tidalApiCacheDir,
                 apiEndpoint,
+                openApiEndpoint,
             )
             .streamingApi
 }

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingPrivilegesModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingPrivilegesModule.kt
@@ -6,6 +6,7 @@ import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.streamingprivileges.StreamingPrivilegesModuleRoot
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
 import javax.inject.Singleton
 import okhttp3.OkHttpClient
 
@@ -19,7 +20,14 @@ internal object StreamingPrivilegesModule {
         gson: Gson,
         @LocalWithCacheAndAuth okHttpClient: OkHttpClient,
         trueTimeWrapper: TrueTimeWrapper,
+        @Named("apiEndpoint") apiEndpoint: String,
     ) =
-        StreamingPrivilegesModuleRoot(connectivityManager, okHttpClient, gson, trueTimeWrapper)
+        StreamingPrivilegesModuleRoot(
+                connectivityManager,
+                okHttpClient,
+                gson,
+                trueTimeWrapper,
+                apiEndpoint,
+            )
             .streamingPrivileges
 }

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
@@ -16,6 +16,7 @@ class StreamingApiModuleRoot(
     offlinePlaybackInfoProvider: OfflinePlaybackInfoProvider?,
     credentialsProvider: CredentialsProvider,
     tidalApiCacheDir: File?,
+    apiEndpoint: String,
 ) {
 
     val streamingApi =
@@ -28,6 +29,7 @@ class StreamingApiModuleRoot(
                 offlinePlaybackInfoProvider,
                 credentialsProvider,
                 tidalApiCacheDir,
+                apiEndpoint,
             )
             .streamingApi
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
@@ -17,6 +17,7 @@ class StreamingApiModuleRoot(
     credentialsProvider: CredentialsProvider,
     tidalApiCacheDir: File?,
     apiEndpoint: String,
+    openApiEndpoint: String,
 ) {
 
     val streamingApi =
@@ -30,6 +31,7 @@ class StreamingApiModuleRoot(
                 credentialsProvider,
                 tidalApiCacheDir,
                 apiEndpoint,
+                openApiEndpoint,
             )
             .streamingApi
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/RetrofitModule.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/RetrofitModule.kt
@@ -1,12 +1,12 @@
 package com.tidal.sdk.player.streamingapi.di
 
-import com.tidal.sdk.player.common.Common.TIDAL_API_ENDPOINT_V1
 import com.tidal.sdk.player.streamingapi.StreamingApiTimeoutConfig
 import com.tidal.sdk.player.streamingapi.drm.api.DrmLicenseService
 import com.tidal.sdk.player.streamingapi.playbackinfo.api.PlaybackInfoService
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.time.toJavaDuration
 import okhttp3.OkHttpClient
@@ -35,9 +35,10 @@ internal object RetrofitModule {
     fun provideRetrofit(
         @StreamingApiComponent.Local okHttpClient: OkHttpClient,
         converterFactory: Converter.Factory,
+        @Named("apiEndpoint") apiEndpoint: String,
     ) =
         Retrofit.Builder()
-            .baseUrl(TIDAL_API_ENDPOINT_V1)
+            .baseUrl(apiEndpoint)
             .client(okHttpClient)
             .addConverterFactory(converterFactory)
             .build()

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
@@ -39,6 +39,7 @@ interface StreamingApiComponent {
             @BindsInstance offlinePlaybackInfoProvider: OfflinePlaybackInfoProvider?,
             @BindsInstance credentialsProvider: CredentialsProvider,
             @BindsInstance @Named("tidalApiCacheDir") tidalApiCacheDir: File?,
+            @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
         ): StreamingApiComponent
     }
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
@@ -40,6 +40,7 @@ interface StreamingApiComponent {
             @BindsInstance credentialsProvider: CredentialsProvider,
             @BindsInstance @Named("tidalApiCacheDir") tidalApiCacheDir: File?,
             @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
+            @BindsInstance @Named("openApiEndpoint") openApiEndpoint: String,
         ): StreamingApiComponent
     }
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiModule.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiModule.kt
@@ -53,8 +53,13 @@ internal object StreamingApiModule {
     fun provideTidalApiClient(
         credentialsProvider: CredentialsProvider,
         @Named("tidalApiCacheDir") cacheDir: File?,
+        @Named("openApiEndpoint") openApiEndpoint: String,
     ): TidalApiClient =
-        TidalApiClient(credentialsProvider, retrofitProvider = RetrofitProvider(cacheDir))
+        TidalApiClient(
+            credentialsProvider,
+            baseUrl = openApiEndpoint,
+            retrofitProvider = RetrofitProvider(cacheDir),
+        )
 
     @Provides
     @Reusable

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
@@ -61,6 +61,7 @@ internal class StreamingApiDefaultTest {
                     credentialsProvider = credentialsProviderMock,
                     tidalApiCacheDir = null,
                     apiEndpoint = Common.TIDAL_API_ENDPOINT_V1,
+                    openApiEndpoint = Common.TIDAL_OPEN_API_ENDPOINT_V2,
                 )
                 .streamingApi
     }

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
 import com.tidal.sdk.player.MockWebServerExtensions.enqueueResponse
+import com.tidal.sdk.player.common.Common
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.di.DaggerStreamingApiComponent
 import com.tidal.sdk.player.streamingapi.offline.OfflinePlaybackInfoProviderStub
@@ -59,6 +60,7 @@ internal class StreamingApiDefaultTest {
                     offlinePlaybackInfoProvider = OfflinePlaybackInfoProviderStub(),
                     credentialsProvider = credentialsProviderMock,
                     tidalApiCacheDir = null,
+                    apiEndpoint = Common.TIDAL_API_ENDPOINT_V1,
                 )
                 .streamingApi
     }

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesModuleRoot.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesModuleRoot.kt
@@ -11,11 +11,12 @@ class StreamingPrivilegesModuleRoot(
     okHttpClient: OkHttpClient,
     gson: Gson,
     trueTimeWrapper: TrueTimeWrapper,
+    apiEndpoint: String,
 ) {
 
     val streamingPrivileges =
         componentFactoryF()
-            .create(connectivityManager, okHttpClient, gson, trueTimeWrapper)
+            .create(connectivityManager, okHttpClient, gson, trueTimeWrapper, apiEndpoint)
             .streamingPrivileges
 
     companion object {

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/di/StreamingPrivilegesComponent.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/di/StreamingPrivilegesComponent.kt
@@ -6,6 +6,7 @@ import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.streamingprivileges.StreamingPrivileges
 import dagger.BindsInstance
 import dagger.Component
+import javax.inject.Named
 import javax.inject.Singleton
 import okhttp3.OkHttpClient
 
@@ -23,6 +24,7 @@ interface StreamingPrivilegesComponent {
             @BindsInstance okHttpClient: OkHttpClient,
             @BindsInstance gson: Gson,
             @BindsInstance trueTimeWrapper: TrueTimeWrapper,
+            @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
         ): StreamingPrivilegesComponent
     }
 }

--- a/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/di/StreamingPrivilegesModule.kt
+++ b/player/streaming-privileges/src/main/kotlin/com/tidal/sdk/player/streamingprivileges/di/StreamingPrivilegesModule.kt
@@ -5,7 +5,6 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
 import com.google.gson.Gson
-import com.tidal.sdk.player.common.Common
 import com.tidal.sdk.player.common.RequestBuilderFactory
 import com.tidal.sdk.player.commonandroid.SystemClockWrapper
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
@@ -32,6 +31,7 @@ import com.tidal.sdk.player.streamingprivileges.messages.incoming.IncomingWebSoc
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
+import javax.inject.Named
 import javax.inject.Singleton
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -57,10 +57,14 @@ internal object StreamingPrivilegesModule {
 
     @Provides
     @Reusable
-    fun retrofit(okHttpClient: OkHttpClient, gsonConverterFactory: GsonConverterFactory) =
+    fun retrofit(
+        okHttpClient: OkHttpClient,
+        gsonConverterFactory: GsonConverterFactory,
+        @Named("apiEndpoint") apiEndpoint: String,
+    ) =
         Retrofit.Builder()
             .client(okHttpClient)
-            .baseUrl(Common.TIDAL_API_ENDPOINT_V1)
+            .baseUrl(apiEndpoint)
             .addConverterFactory(gsonConverterFactory)
             .build()!!
 

--- a/player/streaming-privileges/src/test/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesModuleRootTest.kt
+++ b/player/streaming-privileges/src/test/kotlin/com/tidal/sdk/player/streamingprivileges/StreamingPrivilegesModuleRootTest.kt
@@ -21,8 +21,15 @@ internal class StreamingPrivilegesModuleRootTest {
     private val okHttpClient = mock<OkHttpClient>()
     private val gson = mock<Gson>()
     private val trueTimeWrapper = mock<TrueTimeWrapper>()
+    private val apiEndpoint = "https://api.test.tidal.com/v1/"
     private val streamingPrivilegesModuleRoot by lazy {
-        StreamingPrivilegesModuleRoot(connectivityManager, okHttpClient, gson, trueTimeWrapper)
+        StreamingPrivilegesModuleRoot(
+            connectivityManager,
+            okHttpClient,
+            gson,
+            trueTimeWrapper,
+            apiEndpoint,
+        )
     }
 
     companion object {
@@ -48,14 +55,16 @@ internal class StreamingPrivilegesModuleRootTest {
             mock<StreamingPrivilegesComponent> { on { streamingPrivileges } doReturn expected }
         val componentFactory =
             mock<StreamingPrivilegesComponent.Factory> {
-                on { create(connectivityManager, okHttpClient, gson, trueTimeWrapper) } doReturn
-                    component
+                on {
+                    create(connectivityManager, okHttpClient, gson, trueTimeWrapper, apiEndpoint)
+                } doReturn component
             }
         StreamingPrivilegesModuleRoot.reflectionComponentFactoryF = { componentFactory }
 
         val actual = streamingPrivilegesModuleRoot.streamingPrivileges
 
-        verify(componentFactory).create(connectivityManager, okHttpClient, gson, trueTimeWrapper)
+        verify(componentFactory)
+            .create(connectivityManager, okHttpClient, gson, trueTimeWrapper, apiEndpoint)
         verify(component).streamingPrivileges
         verifyNoMoreInteractions(expected, component, componentFactory)
         assertThat(actual).isSameInstanceAs(expected)


### PR DESCRIPTION
This enables testing the player in stage vs production environments.

Pushes a new player version.