### PR TITLE
Automatic Tidal API module update - 2 files changed

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.34] - 2026-05-14
+### Changed
+- Updated generated code using api spec version 1.9.5
+
 ## [0.3.33] - 2026-05-09
 ### Changed
 - Updated generated code using api spec version 1.9.3

--- a/tidalapi/api-surface.snapshot
+++ b/tidalapi/api-surface.snapshot
@@ -1,5 +1,5 @@
 # TIDAL API Surface Snapshot
-# Spec version: 1.9.3 | Endpoints: 325 | Models: 777
+# Spec version: 1.9.5 | Endpoints: 325 | Models: 777
 
 ## Endpoints
 
@@ -3884,6 +3884,7 @@ UsageRulesCreateOperation_Payload_Data_Attributes
   inherited: boolean (optional)
   paid: array[enum[STREAM, DJ, STEM, DOWNLOAD]] (optional)
   subscription: array[enum[STREAM, DJ, STEM, DOWNLOAD]] (optional)
+  validFrom: string(date-time) (optional)
 
 UsageRulesCreateOperation_Payload_Data_Relationships
   subject: UsageRulesCreateOperation_Payload_Data_Relationships_Subject (required)
@@ -3901,6 +3902,7 @@ UsageRules_Attributes
   inherited: boolean (optional)
   paid: array[enum[STREAM, DJ, STEM, DOWNLOAD]] (optional)
   subscription: array[enum[STREAM, DJ, STEM, DOWNLOAD]] (optional)
+  validFrom: string(date-time) (optional)
 
 UsageRules_Multi_Resource_Data_Document
   data: array[UsageRules_Resource_Object] (required)

--- a/tidalapi/bin/openapi_downloads/tidal-api-oas.json
+++ b/tidalapi/bin/openapi_downloads/tidal-api-oas.json
@@ -8,7 +8,7 @@
     "description" : "The TIDAL API is a [JSON:API](https://jsonapi.org/)–compliant web API that exposes TIDAL’s music, metadata, and user-related functionality through a consistent, resource-oriented design. More information and API management are available at [developer.tidal.com](https://developer.tidal.com)",
     "termsOfService" : "https://developer.tidal.com/documentation/guidelines/guidelines-overview",
     "title" : "TIDAL API",
-    "version" : "1.9.3"
+    "version" : "1.9.5"
   },
   "externalDocs" : {
     "description" : "TIDAL Developer - Documentation",
@@ -28320,6 +28320,7 @@
             "type" : "string"
           },
           "name" : {
+            "minLength" : 1,
             "type" : "string"
           }
         }
@@ -28460,6 +28461,7 @@
             "type" : "string"
           },
           "name" : {
+            "minLength" : 1,
             "type" : "string"
           }
         }
@@ -36273,6 +36275,11 @@
               "type" : "string",
               "enum" : [ "STREAM", "DJ", "STEM", "DOWNLOAD" ]
             }
+          },
+          "validFrom" : {
+            "type" : "string",
+            "description" : "Datetime from which these usage rules are valid (ISO 8601)",
+            "format" : "date-time"
           }
         }
       },
@@ -36345,6 +36352,11 @@
               "description" : "Usage types allowed for subscription model",
               "enum" : [ "STREAM", "DJ", "STEM", "DOWNLOAD" ]
             }
+          },
+          "validFrom" : {
+            "type" : "string",
+            "description" : "Datetime from which these usage rules are valid (ISO 8601)",
+            "format" : "date-time"
           }
         }
       },

--- a/tidalapi/bin/tidal-api.json
+++ b/tidalapi/bin/tidal-api.json
@@ -8,7 +8,7 @@
     "description" : "The TIDAL API is a [JSON:API](https://jsonapi.org/)–compliant web API that exposes TIDAL’s music, metadata, and user-related functionality through a consistent, resource-oriented design. More information and API management are available at [developer.tidal.com](https://developer.tidal.com)",
     "termsOfService" : "https://developer.tidal.com/documentation/guidelines/guidelines-overview",
     "title" : "TIDAL API",
-    "version" : "1.9.3"
+    "version" : "1.9.5"
   },
   "externalDocs" : {
     "description" : "TIDAL Developer - Documentation",
@@ -28320,6 +28320,7 @@
             "type" : "string"
           },
           "name" : {
+            "minLength" : 1,
             "type" : "string"
           }
         }
@@ -28460,6 +28461,7 @@
             "type" : "string"
           },
           "name" : {
+            "minLength" : 1,
             "type" : "string"
           }
         }
@@ -36273,6 +36275,11 @@
               "type" : "string",
               "enum" : [ "STREAM", "DJ", "STEM", "DOWNLOAD" ]
             }
+          },
+          "validFrom" : {
+            "type" : "string",
+            "description" : "Datetime from which these usage rules are valid (ISO 8601)",
+            "format" : "date-time"
           }
         }
       },
@@ -36345,6 +36352,11 @@
               "description" : "Usage types allowed for subscription model",
               "enum" : [ "STREAM", "DJ", "STEM", "DOWNLOAD" ]
             }
+          },
+          "validFrom" : {
+            "type" : "string",
+            "description" : "Datetime from which these usage rules are valid (ISO 8601)",
+            "format" : "date-time"
           }
         }
       },

--- a/tidalapi/gradle.properties
+++ b/tidalapi/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=SDK module wrapping Tidal Open Api
-version=0.3.33
+version=0.3.34

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/models/UsageRulesAttributes.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/models/UsageRulesAttributes.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.Serializable
  *   legacy data).
  * @param paid Usage types allowed for paid/purchase model
  * @param subscription Usage types allowed for subscription model
+ * @param validFrom Datetime from which these usage rules are valid (ISO 8601)
  */
 @Serializable
 data class UsageRulesAttributes(
@@ -40,6 +41,9 @@ data class UsageRulesAttributes(
 
     @SerialName(value = "subscription")
     val subscription: kotlin.collections.List<UsageRulesAttributes.Subscription>? = null,
+    /* Datetime from which these usage rules are valid (ISO 8601) */
+
+    @SerialName(value = "validFrom") val validFrom: kotlin.String? = null,
 ) {
 
     /**

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/models/UsageRulesCreateOperationPayloadDataAttributes.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/models/UsageRulesCreateOperationPayloadDataAttributes.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.Serializable
  *   when providing explicit usage values.
  * @param paid
  * @param subscription
+ * @param validFrom Datetime from which these usage rules are valid (ISO 8601)
  */
 @Serializable
 data class UsageRulesCreateOperationPayloadDataAttributes(
@@ -32,6 +33,9 @@ data class UsageRulesCreateOperationPayloadDataAttributes(
     val subscription:
         kotlin.collections.List<UsageRulesCreateOperationPayloadDataAttributes.Subscription>? =
         null,
+    /* Datetime from which these usage rules are valid (ISO 8601) */
+
+    @SerialName(value = "validFrom") val validFrom: kotlin.String? = null,
 ) {
 
     /** Values: STREAM,DJ,STEM,DOWNLOAD */


### PR DESCRIPTION
Changed files:

M  tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/models/UsageRulesAttributes.kt
M  tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/generated/models/UsageRulesCreateOperationPayloadDataAttributes.kt

API Version: 1.9.5
New module Version: 0.3.34

Automatically generated on Thu May 14 00:21:25 UTC 2026

This PR is automatically updated when API changes are detected.

---

## API Change Analysis
**Spec version**: 1.9.3 -> 1.9.5
**Breaking changes: 0** | Additive changes: 2

### Additive Changes

- `UsageRulesCreateOperation_Payload_Data_Attributes`: added field `validFrom` (optional, string(date-time))
- `UsageRules_Attributes`: added field `validFrom` (optional, string(date-time))
