### PR TITLE
auth: remove spammy getCredentials debug log

### DIFF
--- a/auth/CHANGELOG.md
+++ b/auth/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2026-05-27
+### Changed
+- Remove spammy `getCredentials` debug log from `DefaultCredentialsProvider` to reduce log noise on debug builds
+
 ## [0.11.2] - 2026-04-02
 ### Fixed
 - Fix fatal crash during legacy credential migration caused by removed `InstantIso8601Serializer` in kotlinx-datetime 0.7.x

--- a/auth/gradle.properties
+++ b/auth/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Auth module manages app authentication, authorization, and token handling, simplifying OAuth processes, ensuring secure user access, and offering robust error handling.
-version=0.11.2
+version=0.11.3

--- a/auth/src/main/kotlin/com/tidal/sdk/auth/DefaultCredentialsProvider.kt
+++ b/auth/src/main/kotlin/com/tidal/sdk/auth/DefaultCredentialsProvider.kt
@@ -3,8 +3,6 @@ package com.tidal.sdk.auth
 import com.tidal.sdk.auth.model.AuthResult
 import com.tidal.sdk.auth.model.Credentials
 import com.tidal.sdk.common.TidalMessage
-import com.tidal.sdk.common.d
-import com.tidal.sdk.common.logger
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -18,9 +16,7 @@ internal constructor(
     override val bus: SharedFlow<TidalMessage> = authBus.asSharedFlow()
 
     override suspend fun getCredentials(apiErrorSubStatus: String?): AuthResult<Credentials> {
-        return tokenRepository.getCredentials(apiErrorSubStatus).also {
-            logger.d { "getCredentials called, apiErrorSubStatus: $apiErrorSubStatus, result $it" }
-        }
+        return tokenRepository.getCredentials(apiErrorSubStatus)
     }
 
     override fun isUserLoggedIn() = tokenRepository.getLatestTokens()?.credentials?.userId != null


### PR DESCRIPTION
## Summary
- Remove the `logger.d { "getCredentials called, ..." }` line from `DefaultCredentialsProvider.getCredentials`. It fires on every credentials lookup and floods logcat on debug builds.
- Bump auth module to `0.11.3` and add a changelog entry.

## Test plan
- [ ] CI green
- [ ] Verify logcat on a debug build no longer shows the per-call `getCredentials called, apiErrorSubStatus: ...` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)