### PR TITLE
Ziad/consumer rules

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.41] - 2026-06-02
+### Changed
+- Added consumer-rules.pro
+
 ## [0.3.40] - 2026-05-29
 ### Changed
 - Updated generated code using api spec version 1.10.17

--- a/tidalapi/consumer-rules.pro
+++ b/tidalapi/consumer-rules.pro
@@ -1,0 +1,5 @@
+-keepattributes Signature, InnerClasses, EnclosingMethod
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+-keep interface com.tidal.sdk.tidalapi.generated.apis.** { *; }
+-keep class com.tidal.sdk.tidalapi.generated.models.** { *; }

--- a/tidalapi/gradle.properties
+++ b/tidalapi/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=SDK module wrapping Tidal Open Api
-version=0.3.40
+version=0.3.41


### PR DESCRIPTION
Added `consumer-rules.pro` for the tidalapi to prevent generated apis from being wrongly obfuscated or minified.