### PR TITLE
Fail release workflow loudly when version cannot be resolved

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,11 +29,27 @@ jobs:
           distribution: temurin
       - name: Expose tag and version
         id: expose-tag
+        shell: bash
         run: |
-          version="$(./gradlew ${{ inputs.module }}:properties | grep "^version: " | awk '{print $2}')"
+          set -euo pipefail
+
+          # Run gradle on its own line so a resolution/build failure surfaces
+          # as a non-zero exit instead of being masked by the grep/awk pipe.
+          properties="$(./gradlew ${{ inputs.module }}:properties)"
+          version="$(printf '%s\n' "$properties" | awk '/^version: / {print $2}')"
+
+          # Refuse to emit an empty or unspecified version. Without this guard a
+          # failed gradle run produced an empty tag ("${{ inputs.module }}-"),
+          # which silently passed here and only failed three jobs later with a
+          # confusing GitHub "422 tag_name is not well-formed" error.
+          if [[ -z "$version" || "$version" == "unspecified" ]]; then
+            echo "::error::Could not resolve a version for '${{ inputs.module }}' (got '$version'). Failing instead of emitting an invalid tag." >&2
+            exit 1
+          fi
+
           tag="${{ inputs.module }}-$version"
-          echo "version=$version" >> $GITHUB_OUTPUT
-          echo "tag=$tag" >> $GITHUB_OUTPUT
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
   publish-to-gh-packages:
     name: Publish packages to Github Packages


### PR DESCRIPTION
## Problem

Post-Merge run [26815508908](https://github.com/tidal-music/tidal-sdk-android/actions/runs/26815508908) failed in the `Publish packages to Github Packages` job with:

```
Error 422: Validation Failed: tag_name is not a valid tag / tag_name is not well-formed
```

Root cause chain:

1. The upstream `Expose tag and version` job computes the version with a single pipeline:
   ```bash
   version="$(./gradlew <module>:properties | grep "^version: " | awk '{print $2}')"
   ```
2. A transient Maven Central **403 Forbidden** broke Kotlin artifact resolution, so `./gradlew :properties` failed.
3. A shell pipeline reports only the **last** command's exit code (`awk`, which exits 0), so the gradle failure was swallowed — `version` came out empty and the step **still exited 0 (green)**.
4. The tag became `<module>-` (empty version) and flowed downstream into the GH Packages release, which the GitHub API rejected with the confusing 422.

The release itself was recoverable by simply re-running the workflow (Maven Central recovered), but the failure mode was silent and the error message pointed at the wrong job.

## Fix

Harden the `Expose tag and version` step:

- `set -euo pipefail` so a failing `gradlew` fails the step.
- Run `gradlew` on its own line so its exit code is not masked by the `grep`/`awk` pipe.
- Reject empty / `unspecified` versions before building the tag, with a clear `::error::` message.

Both publish jobs already declare `needs: [expose-tag]`, so on failure they are now **skipped** instead of receiving an invalid tag — the run fails fast at the real cause.

## Effect

A future transient resolution failure now produces a clearly-failed `Expose tag and version` job ("Could not resolve a version…") that a re-run fixes, instead of a green job emitting a `<module>-` tag and a misleading 422 three jobs later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)