### PR TITLE
Stop pre-existing FOSSA backlog from blocking PRs (diff-mode + main baseline)

### DIFF
--- a/.github/workflows/fossa-scan.yml
+++ b/.github/workflows/fossa-scan.yml
@@ -2,6 +2,22 @@ name: FOSSA Scans
 
 on:
   workflow_call:
+    inputs:
+      base-sha:
+        description: "Base revision for `fossa test --diff`. When empty, the diff test is skipped."
+        required: false
+        type: string
+        default: ""
+      branch:
+        description: "FOSSA branch label for the analyze step. When empty, fossa-cli detects it."
+        required: false
+        type: string
+        default: ""
+      run-fossa-tests:
+        description: "Run `fossa test`. Set false for analyze-only baseline runs."
+        required: false
+        type: boolean
+        default: true
     secrets:
       pat:
         required: true
@@ -13,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so fossa-cli resolves the revision/branch.
+          fetch-depth: 0
       - uses: gradle/gradle-build-action@v3
       - uses: actions/setup-java@v4
         with:
@@ -20,12 +39,18 @@ jobs:
           distribution: temurin
 
       - name: "Run FOSSA Scan"
-        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac
+        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7
         with:
           api-key: ${{secrets.fossaApiKey}}
+          branch: ${{ inputs.branch }}
 
       - name: "Run FOSSA Tests"
-        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac
+        # Skipped on analyze-only baseline runs (no base revision supplied).
+        if: ${{ inputs.run-fossa-tests && inputs.base-sha != '' }}
+        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7
         with:
           api-key: ${{secrets.fossaApiKey}}
           run-tests: true
+          # Diff mode: fail only on issues introduced vs the base revision, so
+          # the pre-existing backlog stops blocking unrelated PRs.
+          test-diff-revision: ${{ inputs.base-sha }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,6 +8,17 @@ concurrency:
 
 jobs:
 
+  fossa-baseline:
+    name: FOSSA baseline scan (main)
+    # Analyze-only scan of `main` so PRs have a labelled baseline to diff against.
+    uses: ./.github/workflows/fossa-scan.yml
+    with:
+      branch: main
+      run-fossa-tests: false
+    secrets:
+      pat: ${{ secrets.PACKAGES_PAT }}
+      fossaApiKey: ${{ secrets.FOSSA_API_KEY_FULL }}
+
   build-module-list:
     runs-on: ubuntu-latest
     name: Generate candidate SDK module list

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,6 +31,9 @@ jobs:
   trigger-fossa-scan:
     name: Trigger FOSSA Scan
     uses: ./.github/workflows/fossa-scan.yml
+    with:
+      # Base revision for `fossa test --diff` (key differs per event).
+      base-sha: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
     secrets:
       pat: ${{ secrets.PACKAGES_PAT }}
       fossaApiKey: ${{ secrets.FOSSA_API_KEY_FULL }}


### PR DESCRIPTION
## Problem

The `Trigger FOSSA Scan / fossa-scan` check failed on **every** PR, blocking merge. It was not PR-specific: `fossa test` evaluated the entire dependency baseline against the server-side policy and exited 1 on any of the **50 pre-existing issues** — so unrelated PRs failed identically.

## Triage (FOSSA dashboard)

- **All 50 are security vulnerabilities** (0 licensing).
- **All 50 live in build-time Gradle tooling**, not in the shipped SDK: transitive deps of the Android Gradle Plugin and the maven-publish plugin — Netty (~44), Bouncy Castle, Protocol Buffers, Apache HttpClient, OpenTelemetry.
- **Verified not shipped:** none appear in any module's `releaseRuntimeClasspath`; they only appear in the root buildscript classpath. SDK consumers are not exposed.

## Approach

Rather than narrow the scan (which would drop coverage of the published `:bom` platform and the plugin classpath), **keep full scan coverage** and switch the PR gate to **diff mode** — fail only on issues a change *introduces*, not the pre-existing backlog. Diff mode needs a FOSSA-analyzed baseline for the base commit, which this PR establishes on `main`.

### Changes

- **`fossa-scan.yml`** — parameterized with `base-sha`, `branch`, `run-fossa-tests`. The test step runs `fossa test --diff <base-sha>` and is skipped when no base SHA is supplied. `fetch-depth: 0` so fossa-cli resolves the revision/branch.
- **`pull-request.yml`** — compute the base SHA from the `pull_request` / `merge_group` event and pass it as `base-sha`.
- **`post-merge.yml`** — new `fossa-baseline` job runs `fossa analyze` on push to `main` (labelled `main`, analyze-only). Establishes a baseline for every main commit and makes FOSSA track the real default branch.

`fossa analyze` still uploads on PRs, so scan coverage is unchanged and new regressions are still caught.

## Known limitations / follow-ups

- **Bootstrapping:** the `main` baseline only exists after this merges, so this PR's own `fossa-scan` check will likely stay red and needs an admin/override merge. Subsequent PRs are green.
- **Baseline race:** a PR based on a just-merged main commit may run before that commit's baseline finishes → a spurious failure that clears on re-run.
- **Non-`main` base branches** diff against an unscanned base (baselines run on `main` only); repo is trunk-based so not expected.
- **Dashboard:** once the first `main` baseline lands, switch the FOSSA project Default Branch to `main`. The 50 stay in the dashboard (build tooling, not product risk) — no upgrade/waiver needed for the gate.