### PR TITLE
Add UriSchemeType arg for StreamingApi track and video manifest

### DIFF
--- a/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/UriSchemeType.kt
+++ b/player/common/src/main/kotlin/com/tidal/sdk/player/common/model/UriSchemeType.kt
@@ -1,0 +1,10 @@
+package com.tidal.sdk.player.common.model
+
+import androidx.annotation.Keep
+
+/** The scheme type of a Uri */
+@Keep
+enum class UriSchemeType {
+    DATA,
+    HTTPS,
+}

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
@@ -5,6 +5,7 @@ import com.tidal.sdk.player.common.ForwardingMediaProduct
 import com.tidal.sdk.player.common.model.AudioQuality
 import com.tidal.sdk.player.common.model.Extras
 import com.tidal.sdk.player.common.model.ProductType
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.EventReporter
@@ -117,6 +118,7 @@ internal class StreamingApiRepository(
                             audioModeRepository.immersiveAudio,
                             streamingSessionId,
                             audioQualityRepository.enableAdaptive,
+                            UriSchemeType.DATA,
                         )
 
                     ProductType.VIDEO ->
@@ -125,6 +127,7 @@ internal class StreamingApiRepository(
                             videoQualityRepository.streamingQuality,
                             PlaybackMode.STREAM,
                             streamingSessionId,
+                            UriSchemeType.DATA,
                         )
 
                     ProductType.BROADCAST ->

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.tidal.sdk.player.common.ForwardingMediaProduct
 import com.tidal.sdk.player.common.model.AudioQuality
 import com.tidal.sdk.player.common.model.ProductQuality
 import com.tidal.sdk.player.common.model.ProductType
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.EventReporter
@@ -172,6 +173,7 @@ internal class StreamingApiRepositoryTest {
                                 false,
                                 "streamingSessionId",
                                 enableAdaptive = false,
+                                uriSchemeType = UriSchemeType.DATA,
                             )
                         )
                         .thenReturn(expected)
@@ -186,6 +188,7 @@ internal class StreamingApiRepositoryTest {
                                 productQuality,
                                 playbackMode,
                                 "streamingSessionId",
+                                UriSchemeType.DATA,
                             )
                         )
                         .thenReturn(expected)
@@ -286,6 +289,7 @@ internal class StreamingApiRepositoryTest {
                                 false,
                                 "streamingSessionId",
                                 enableAdaptive = false,
+                                uriSchemeType = UriSchemeType.DATA,
                             )
                         )
                         .thenThrow(runtimeException)
@@ -300,6 +304,7 @@ internal class StreamingApiRepositoryTest {
                                 productQuality,
                                 playbackMode,
                                 "streamingSessionId",
+                                UriSchemeType.DATA,
                             )
                         )
                         .thenThrow(runtimeException)

--- a/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
+++ b/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
@@ -7,6 +7,7 @@ import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.StreamingApiTimeoutConfig
@@ -93,6 +94,7 @@ private class PlayLogTestStreamingApi(private val trackPlaybackInfo: PlaybackInf
         immersiveAudio: Boolean,
         streamingSessionId: String,
         enableAdaptive: Boolean,
+        uriSchemeType: UriSchemeType,
     ): PlaybackInfo {
         return trackPlaybackInfo.copy(streamingSessionId = streamingSessionId)
     }
@@ -102,6 +104,7 @@ private class PlayLogTestStreamingApi(private val trackPlaybackInfo: PlaybackInf
         videoQuality: VideoQuality,
         playbackMode: PlaybackMode,
         streamingSessionId: String,
+        uriSchemeType: UriSchemeType,
         playlistUuid: String?,
     ): PlaybackInfo {
         throw UnsupportedOperationException("Not implemented for playlog test")

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApi.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApi.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.streamingapi
 
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
@@ -23,6 +24,7 @@ interface StreamingApi {
      * @param[streamingSessionId] The streaming session uuid as [String], created by the client, for
      *   this streaming session.
      * @param[enableAdaptive] Whether to enable adaptive streaming.
+     * @param[uriSchemeType] The manifest URI scheme to request. [UriSchemeType]
      */
     @Suppress("LongParameterList")
     suspend fun getTrackPlaybackInfo(
@@ -32,6 +34,7 @@ interface StreamingApi {
         immersiveAudio: Boolean,
         streamingSessionId: String,
         enableAdaptive: Boolean,
+        uriSchemeType: UriSchemeType,
     ): PlaybackInfo
 
     /**
@@ -43,12 +46,14 @@ interface StreamingApi {
      * @param[streamingSessionId] The streaming session uuid as [String], created by the client, for
      *   this streaming session.
      * @param[playlistUuid] The playlistUuid this play originates from as [String]. May be null.
+     * @param[uriSchemeType] The manifest URI scheme to request. [UriSchemeType]
      */
     suspend fun getVideoPlaybackInfo(
         videoId: String,
         videoQuality: VideoQuality,
         playbackMode: PlaybackMode,
         streamingSessionId: String,
+        uriSchemeType: UriSchemeType,
         playlistUuid: String? = null,
     ): PlaybackInfo
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefault.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefault.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.streamingapi
 
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.streamingapi.drm.repository.DrmLicenseRepository
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
@@ -25,6 +26,7 @@ internal class StreamingApiDefault(
         immersiveAudio: Boolean,
         streamingSessionId: String,
         enableAdaptive: Boolean,
+        uriSchemeType: UriSchemeType,
     ) =
         playbackInfoRepository.getTrackPlaybackInfo(
             trackId,
@@ -33,6 +35,7 @@ internal class StreamingApiDefault(
             immersiveAudio,
             streamingSessionId,
             enableAdaptive,
+            uriSchemeType,
         )
 
     override suspend fun getVideoPlaybackInfo(
@@ -40,6 +43,7 @@ internal class StreamingApiDefault(
         videoQuality: VideoQuality,
         playbackMode: PlaybackMode,
         streamingSessionId: String,
+        uriSchemeType: UriSchemeType,
         playlistUuid: String?,
     ) =
         playbackInfoRepository.getVideoPlaybackInfo(
@@ -48,6 +52,7 @@ internal class StreamingApiDefault(
             playbackMode,
             streamingSessionId,
             playlistUuid,
+            uriSchemeType,
         )
 
     override suspend fun getBroadcastPlaybackInfo(

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepository.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepository.kt
@@ -1,6 +1,7 @@
 package com.tidal.sdk.player.streamingapi.playbackinfo.repository
 
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
@@ -18,6 +19,7 @@ internal interface PlaybackInfoRepository {
      * @param[streamingSessionId] The streaming session uuid as [String], created by the client, for
      *   this streaming session.
      * @param[enableAdaptive] Whether to enable adaptive streaming.
+     * @param[uriSchemeType] The manifest URI scheme to request. [UriSchemeType]
      */
     suspend fun getTrackPlaybackInfo(
         trackId: String,
@@ -26,6 +28,7 @@ internal interface PlaybackInfoRepository {
         immersiveAudio: Boolean,
         streamingSessionId: String,
         enableAdaptive: Boolean,
+        uriSchemeType: UriSchemeType,
     ): PlaybackInfo
 
     /**
@@ -37,6 +40,7 @@ internal interface PlaybackInfoRepository {
      * @param[streamingSessionId] The streaming session uuid as [String], created by the client, for
      *   this streaming session.
      * @param[playlistUuid] The playlistUuid this play originates from as [String]. May be null.
+     * @param[uriSchemeType] The manifest URI scheme to request. [UriSchemeType]
      */
     suspend fun getVideoPlaybackInfo(
         videoId: String,
@@ -44,6 +48,7 @@ internal interface PlaybackInfoRepository {
         playbackMode: PlaybackMode,
         streamingSessionId: String,
         playlistUuid: String?,
+        uriSchemeType: UriSchemeType,
     ): PlaybackInfo
 
     /**

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefault.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefault.kt
@@ -5,6 +5,7 @@ import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
 import com.tidal.sdk.player.common.model.PreviewReason
 import com.tidal.sdk.player.common.model.StreamType
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.streamingapi.playbackinfo.api.PlaybackInfoService
 import com.tidal.sdk.player.streamingapi.playbackinfo.mapper.ApiErrorMapper
@@ -48,6 +49,7 @@ internal class PlaybackInfoRepositoryDefault(
         immersiveAudio: Boolean,
         streamingSessionId: String,
         enableAdaptive: Boolean,
+        uriSchemeType: UriSchemeType,
     ) =
         try {
             val response =
@@ -55,7 +57,9 @@ internal class PlaybackInfoRepositoryDefault(
                     id = trackId,
                     manifestType = TrackManifests.ManifestTypeTrackManifestsIdGet.MPEG_DASH,
                     formats = getRequestedFormats(audioQuality, immersiveAudio),
-                    uriScheme = UriSchemeTrackManifestsIdGet.DATA,
+                    uriScheme =
+                        if (uriSchemeType == UriSchemeType.HTTPS) UriSchemeTrackManifestsIdGet.HTTPS
+                        else UriSchemeTrackManifestsIdGet.DATA,
                     usage =
                         if (playbackMode == PlaybackMode.STREAM) UsageTrackManifestsIdGet.PLAYBACK
                         else UsageTrackManifestsIdGet.DOWNLOAD,
@@ -63,6 +67,10 @@ internal class PlaybackInfoRepositoryDefault(
                 )
             if (!response.isSuccessful) throw HttpException(response)
             val data = response.body()?.data
+            val manifestUri = data?.attributes?.uri.orEmpty()
+            val manifest =
+                if (uriSchemeType == UriSchemeType.DATA) extractManifest(manifestUri)
+                else manifestUri
             PlaybackInfo.Track(
                 trackId = data?.id?.toInt() ?: -1,
                 audioQuality = getAudioQualityFromFormats(data?.attributes?.formats, audioQuality),
@@ -72,7 +80,7 @@ internal class PlaybackInfoRepositoryDefault(
                 manifestHash = data?.attributes?.hash.orEmpty(),
                 streamingSessionId = streamingSessionId,
                 manifestMimeType = ManifestMimeType.DASH,
-                manifest = extractManifest(data?.attributes?.uri.orEmpty()),
+                manifest = manifest,
                 licenseUrl = data?.attributes?.drmData?.licenseUrl,
                 albumReplayGain = data?.attributes?.albumAudioNormalizationData?.replayGain ?: -1f,
                 albumPeakAmplitude =
@@ -198,12 +206,15 @@ internal class PlaybackInfoRepositoryDefault(
         playbackMode: PlaybackMode,
         streamingSessionId: String,
         playlistUuid: String?,
+        uriSchemeType: UriSchemeType,
     ) =
         try {
             val response =
                 videoManifests.videoManifestsIdGet(
                     id = videoId,
-                    uriScheme = UriSchemeVideoManifestsIdGet.DATA,
+                    uriScheme =
+                        if (uriSchemeType == UriSchemeType.HTTPS) UriSchemeVideoManifestsIdGet.HTTPS
+                        else UriSchemeVideoManifestsIdGet.DATA,
                     usage =
                         if (playbackMode == PlaybackMode.STREAM) UsageVideoManifestsIdGet.PLAYBACK
                         else UsageVideoManifestsIdGet.DOWNLOAD,

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefaultTest.kt
@@ -22,6 +22,7 @@ import com.tidal.sdk.player.streamingapi.playbackinfo.mapper.ApiErrorMapper
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.ManifestMimeType
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
+import com.tidal.sdk.tidalapi.generated.apis.TrackManifests.UriSchemeTrackManifestsIdGet
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -80,6 +81,7 @@ internal class PlaybackInfoRepositoryDefaultTest {
             true,
             streamingSessionId,
             false,
+            UriSchemeTrackManifestsIdGet.DATA,
         )
 
     @Test


### PR DESCRIPTION
Adding the ability to provide `UriSchemeType` arg for `StreamingApi` track and video manifests. User of `StreamingApi` can provide what uri scheme the request should return.