### PR TITLE
Fix ConcurrentModificationException when serializing playback session events

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/ExoPlayerPlaybackEngine.kt
@@ -1126,7 +1126,7 @@ internal class ExoPlayerPlaybackEngine(
                             actualQuality,
                             sourceType,
                             sourceId,
-                            actions,
+                            actions.toList(),
                             endTimestamp,
                             endPositionSeconds,
                         )
@@ -1142,7 +1142,7 @@ internal class ExoPlayerPlaybackEngine(
                             actualQuality,
                             sourceType,
                             sourceId,
-                            actions,
+                            actions.toList(),
                             endTimestamp,
                             endPositionSeconds,
                         )
@@ -1157,7 +1157,7 @@ internal class ExoPlayerPlaybackEngine(
                             actualQuality,
                             sourceType,
                             sourceId,
-                            actions,
+                            actions.toList(),
                             endTimestamp,
                             endPositionSeconds,
                         )
@@ -1172,7 +1172,7 @@ internal class ExoPlayerPlaybackEngine(
                             actualQuality,
                             sourceType,
                             sourceId,
-                            actions,
+                            actions.toList(),
                             endTimestamp,
                             endPositionSeconds,
                         )


### PR DESCRIPTION
PlaybackSession events were reported by passing the session's live `actions` MutableList directly into the event payload.

DefaultEventReporter serializes events with Gson on a background coroutine, while the playback engine thread continues appending to the same list (e.g. on seek/transition in handleTransition). Gson's  CollectionTypeAdapter iterating the list during this concurrent mutation threw ConcurrentModificationException.

Pass a defensive snapshot (actions.toList()) when building the playback session payloads so serialization operates on an independent immutable copy, eliminating the race.