### PR TITLE
Fix PlaybackInfoRepositoryDefaultTest for UriSchemeType param

### DIFF
--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/playbackinfo/repository/PlaybackInfoRepositoryDefaultTest.kt
@@ -9,6 +9,7 @@ import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
 import com.tidal.sdk.player.common.model.AudioQuality
+import com.tidal.sdk.player.common.model.UriSchemeType
 import com.tidal.sdk.player.common.model.VideoQuality
 import com.tidal.sdk.player.streamingapi.ApiConstants
 import com.tidal.sdk.player.streamingapi.TrackPlaybackInfoFactory
@@ -22,7 +23,6 @@ import com.tidal.sdk.player.streamingapi.playbackinfo.mapper.ApiErrorMapper
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.ManifestMimeType
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
-import com.tidal.sdk.tidalapi.generated.apis.TrackManifests.UriSchemeTrackManifestsIdGet
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -81,7 +81,7 @@ internal class PlaybackInfoRepositoryDefaultTest {
             true,
             streamingSessionId,
             false,
-            UriSchemeTrackManifestsIdGet.DATA,
+            UriSchemeType.DATA,
         )
 
     @Test
@@ -124,6 +124,7 @@ internal class PlaybackInfoRepositoryDefaultTest {
             PlaybackMode.STREAM,
             streamingSessionId,
             null,
+            UriSchemeType.DATA,
         )
 
     @Test


### PR DESCRIPTION
## Problem
`:player:streaming-api:compileDebugUnitTestKotlin` fails to compile on `main`:

```
PlaybackInfoRepositoryDefaultTest.kt:84  actual type 'TrackManifests.UriSchemeTrackManifestsIdGet', but 'UriSchemeType' was expected
PlaybackInfoRepositoryDefaultTest.kt:126 No value passed for parameter 'uriSchemeType'
```

PR #314 introduced the `player.common.model.UriSchemeType` abstraction and added a `uriSchemeType` parameter to `PlaybackInfoRepository.getTrackPlaybackInfo` / `getVideoPlaybackInfo`, and updated `StreamingApiRepositoryTest` — but missed `PlaybackInfoRepositoryDefaultTest`. So the test module doesn't compile whenever the full suite runs (it slips through when affected-module detection skips `player`).

## Fix
Update the test to use the new domain enum:
- `getTrackPlaybackInfo` helper: leftover generated `TrackManifests.UriSchemeTrackManifestsIdGet.DATA` → `UriSchemeType.DATA`
- `getVideoPlaybackInfo` helper: add the missing `uriSchemeType = UriSchemeType.DATA` argument
- swap the import accordingly

## Verification
- `./gradlew :player:streaming-api:compileDebugUnitTestKotlin` → BUILD SUCCESSFUL
- `./gradlew :player:streaming-api:testDebugUnitTest --tests "*PlaybackInfoRepositoryDefaultTest*"` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)