### PR TITLE
TM-1414: tidalapi HTTP retry for read calls (TIDE-1891)

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/BackoffSpec.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/BackoffSpec.kt
@@ -1,0 +1,56 @@
+package com.tidal.sdk.tidalapi.networking
+
+import kotlin.math.min
+
+/** The category of failure a retry attempt is reacting to. */
+enum class ErrorCategory {
+    /** A retryable HTTP status: response code 429 or any 5xx. */
+    HTTP_STATUS,
+
+    /** A read/connect timeout (`java.net.SocketTimeoutException`). */
+    TIMEOUT,
+
+    /** A non-timeout transport failure (other `IOException`: DNS, TLS, connection, …). */
+    NETWORK,
+}
+
+/**
+ * Per-category exponential-backoff configuration. Pure and OkHttp-free so it can be reasoned about
+ * and tested in isolation.
+ *
+ * @param baseMillis the base delay `B`, applied before the first retry.
+ * @param maxMillis the cap `M`, an upper bound on the capped (pre-jitter) delay.
+ * @param maxRetries the number of retries `N` allowed after the first attempt, for this category.
+ */
+data class BackoffSpec(val baseMillis: Long, val maxMillis: Long, val maxRetries: Int) {
+
+    /**
+     * Computes the backoff delay, in milliseconds, before the next retry [attempt] (0-based).
+     *
+     * Follows `D = min(B·2ⁿ, M)` then `× j`, applying the cap **before** jitter to match the iOS
+     * `JitteredBackoffPolicy` (a deliberate divergence from the literal jitter-then-cap ordering).
+     * The jitter factor `j` falls in the band `[0.8, 1.0]` via `0.8 + 0.2 · random()`. [random] is
+     * injected (defaulting to [Math.random] at the call site) for deterministic tests.
+     */
+    @Suppress("MagicNumber")
+    fun computeDelayMillis(attempt: Int, random: () -> Double): Long {
+        val capped = cappedDelayMillis(attempt)
+        return (capped * (0.8 + 0.2 * random())).toLong()
+    }
+
+    /**
+     * `min(baseMillis · 2^attempt, maxMillis)`, grown step-by-step and clamped to [maxMillis] as
+     * soon as a further doubling would exceed it. Computing the growth iteratively (rather than via
+     * `baseMillis * (1L shl attempt)`) avoids the `Long` shift wrapping at `attempt >= 64` and the
+     * multiplication overflowing, so an oversized attempt index saturates at the cap instead of
+     * producing a small or negative delay.
+     */
+    private fun cappedDelayMillis(attempt: Int): Long {
+        var capped = min(baseMillis, maxMillis)
+        repeat(attempt) {
+            if (capped >= maxMillis / 2) return maxMillis
+            capped *= 2
+        }
+        return capped
+    }
+}

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -5,6 +5,7 @@ import com.tidal.sdk.common.d
 import com.tidal.sdk.common.logger
 import com.tidal.sdk.tidalapi.generated.models.getOneOfSerializer
 import java.io.File
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import okhttp3.Cache
@@ -16,9 +17,22 @@ import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 
-class RetrofitProvider(
+/**
+ * @param[retryPolicy] The [RetryPolicy] driving automatic retry of failed requests. Defaults to
+ *   [DefaultRetryPolicy] (the three-category model, retrying GET/HEAD only). Pass `null` to disable
+ *   retry entirely.
+ * @param[readTimeoutMillis] The OkHttp read timeout, in milliseconds. Defaults to
+ *   [DEFAULT_READ_TIMEOUT_MILLIS] (5s). A read that exceeds it surfaces a `SocketTimeoutException`,
+ *   which the retry interceptor classifies as a timeout. (The 5s default is below the timeout
+ *   category's 8s base delay; the intended relationship is still being confirmed.)
+ */
+class RetrofitProvider
+@JvmOverloads
+constructor(
     private val cacheDir: File? = null,
     private val cacheSize: Long = DEFAULT_CACHE_SIZE,
+    private val retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
+    private val readTimeoutMillis: Long = DEFAULT_READ_TIMEOUT_MILLIS,
 ) {
 
     private val converterFactories: List<Converter.Factory> =
@@ -29,7 +43,9 @@ class RetrofitProvider(
 
     private fun provideOkHttpClient(credentialsProvider: CredentialsProvider): OkHttpClient =
         OkHttpClient.Builder()
+            .readTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
             .apply { cacheDir?.let { cache(Cache(it, cacheSize)) } }
+            .apply { retryPolicy?.let { addInterceptor(RetryInterceptor(it)) } }
             .addInterceptor(AuthInterceptor(credentialsProvider))
             .authenticator(DefaultAuthenticator(credentialsProvider))
             .addInterceptor(getLoggingInterceptor())
@@ -44,6 +60,7 @@ class RetrofitProvider(
 
     companion object {
         const val DEFAULT_CACHE_SIZE = 10L * 1024 * 1024 // 10 MB
+        const val DEFAULT_READ_TIMEOUT_MILLIS = 5_000L
     }
 
     private fun getLoggingInterceptor(): HttpLoggingInterceptor {

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifier.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifier.kt
@@ -1,0 +1,26 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import okhttp3.Response
+
+/**
+ * Classifies the outcome of a request attempt into the [ErrorCategory] that governs its retry, or
+ * `null` when the outcome is not retryable.
+ *
+ * A thrown [SocketTimeoutException] is a [TIMEOUT][ErrorCategory.TIMEOUT]; any other [IOException]
+ * is a [NETWORK][ErrorCategory.NETWORK] failure (DNS, TLS, connection, …). A non-`IOException`
+ * throwable is never retried (it is rethrown by the caller). For a returned response, only code 429
+ * or a 5xx is an [HTTP_STATUS][ErrorCategory.HTTP_STATUS] failure; 2xx/3xx, 401 (left to
+ * [DefaultAuthenticator]) and every other 4xx are deliberately non-retryable.
+ */
+@Suppress("MagicNumber")
+internal fun classify(response: Response?, error: Throwable?): ErrorCategory? =
+    when {
+        error is SocketTimeoutException -> ErrorCategory.TIMEOUT
+        error is IOException -> ErrorCategory.NETWORK
+        error != null -> null
+        response != null && (response.code == 429 || response.code in 500..599) ->
+            ErrorCategory.HTTP_STATUS
+        else -> null
+    }

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptor.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptor.kt
@@ -1,0 +1,91 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import okhttp3.Interceptor
+import okhttp3.Response
+
+private const val IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+
+/**
+ * An [Interceptor] that transparently retries failed requests according to the three-error-category
+ * [RetryPolicy]. It sits below Retrofit's type layer, so the `Response<T>` consumer contract is
+ * untouched.
+ *
+ * Only retry-eligible requests are retried — Step 1 gates this to the idempotent verbs GET and HEAD
+ * (see [RetryPolicy.isRetryableRequest]); mutations pass through once. Each failed attempt is
+ * mapped to an [ErrorCategory] by [classify], and that category's [BackoffSpec] drives the wait.
+ * Attempt counts are tracked per category, so a run of timeouts does not consume the network retry
+ * budget. 401 is never retried here — it is left to the [DefaultAuthenticator].
+ *
+ * Backoff blocks the OkHttp dispatcher thread via [sleep]; this is consistent with the existing
+ * [AuthInterceptor]/[DefaultAuthenticator], which already block on these threads. [sleep] and
+ * [random] are injected (with production defaults) for deterministic tests.
+ */
+internal class RetryInterceptor(
+    private val policy: RetryPolicy,
+    private val random: () -> Double = Math::random,
+    private val sleep: (Long) -> Unit = Thread::sleep,
+) : Interceptor {
+
+    @Suppress("ReturnCount")
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val hasKey = !request.header(IDEMPOTENCY_KEY_HEADER).isNullOrBlank()
+        if (!policy.isRetryableRequest(request.method, hasKey)) {
+            return chain.proceed(request)
+        }
+
+        val attempts = IntArray(ErrorCategory.entries.size)
+        while (true) {
+            var response: Response? = null
+            val category =
+                try {
+                    response = chain.proceed(request)
+                    classify(response, error = null)
+                } catch (e: IOException) {
+                    // A non-retryable throwable (incl. non-IOException) propagates directly. A
+                    // retryable transport failure backs off and loops, or rethrows once the
+                    // category's budget is spent.
+                    val errorCategory = classify(response = null, error = e) ?: throw e
+                    if (hasBudget(attempts, errorCategory)) {
+                        backOff(chain, attempts, errorCategory)
+                        continue
+                    }
+                    throw e
+                }
+            // A non-retryable response (2xx/3xx, 401, non-429 4xx) or a spent budget surfaces the
+            // response unchanged with its body intact.
+            val nonNullResponse = requireNotNull(response)
+            if (category == null || !hasBudget(attempts, category)) {
+                return nonNullResponse
+            }
+            // Committed to retrying: free the body first so it is never leaked even if the backoff
+            // is aborted by cancellation.
+            nonNullResponse.close()
+            backOff(chain, attempts, category)
+        }
+    }
+
+    /** Whether [category] has any retry attempt left. */
+    private fun hasBudget(attempts: IntArray, category: ErrorCategory): Boolean =
+        attempts[category.ordinal] < policy.specFor(category).maxRetries
+
+    /**
+     * Waits the backoff for [category] and records the attempt. A cancelled call aborts retrying
+     * promptly: [Thread.sleep] is not woken by [okhttp3.Call.cancel], so the call's cancelled state
+     * is checked around the sleep and an [InterruptedException] also ends the wait. In every abort
+     * case an [IOException] is thrown so the caller observes the cancellation rather than a stale
+     * (un-retried) failure response. Call only when [hasBudget] is true.
+     */
+    private fun backOff(chain: Interceptor.Chain, attempts: IntArray, category: ErrorCategory) {
+        if (chain.call().isCanceled()) throw IOException("Canceled")
+        try {
+            sleep(policy.specFor(category).computeDelayMillis(attempts[category.ordinal], random))
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw IOException("Retry backoff interrupted", e)
+        }
+        if (chain.call().isCanceled()) throw IOException("Canceled")
+        attempts[category.ordinal]++
+    }
+}

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicy.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicy.kt
@@ -1,0 +1,50 @@
+package com.tidal.sdk.tidalapi.networking
+
+/**
+ * Policy defining how a tidalapi network call should be retried, following a three-error-category
+ * model. Tidalapi-local and free of any auth/common/OkHttp types so it can be reasoned about and
+ * tested in isolation.
+ *
+ * Each category carries its own [BackoffSpec] (base/max/retries) and the categories' attempt counts
+ * are tracked independently by the interceptor, so exhausting one category's retries does not
+ * consume another's budget.
+ */
+interface RetryPolicy {
+    /** Backoff for retryable HTTP statuses (429 or 5xx). */
+    val httpStatus: BackoffSpec
+
+    /** Backoff for read/connect timeouts (`java.net.SocketTimeoutException`). */
+    val timeout: BackoffSpec
+
+    /** Backoff for other transport failures (DNS, TLS, connection, …). */
+    val network: BackoffSpec
+
+    /** The [BackoffSpec] governing the given [category]. */
+    fun specFor(category: ErrorCategory): BackoffSpec =
+        when (category) {
+            ErrorCategory.HTTP_STATUS -> httpStatus
+            ErrorCategory.TIMEOUT -> timeout
+            ErrorCategory.NETWORK -> network
+        }
+
+    /**
+     * Whether a request is retry-eligible by method. Step 1 retries the idempotent verbs GET and
+     * HEAD only; mutations are never retried. [hasIdempotencyKey] is accepted (so the signature is
+     * stable into the keyed-write follow-up) but ignored here.
+     */
+    fun isRetryableRequest(method: String, hasIdempotencyKey: Boolean): Boolean =
+        method in setOf("GET", "HEAD")
+}
+
+/**
+ * Enabled-by-default policy with the per-category constants:
+ * - HTTP status (429 / 5xx): base 500 ms, cap 16 s, 3 retries.
+ * - Timeout: base 8 s, cap 32 s, 3 retries.
+ * - Network: base 1 s, cap 16 s, 10 retries.
+ */
+@Suppress("MagicNumber")
+class DefaultRetryPolicy : RetryPolicy {
+    override val httpStatus = BackoffSpec(baseMillis = 500L, maxMillis = 16_000L, maxRetries = 3)
+    override val timeout = BackoffSpec(baseMillis = 8_000L, maxMillis = 32_000L, maxRetries = 3)
+    override val network = BackoffSpec(baseMillis = 1_000L, maxMillis = 16_000L, maxRetries = 10)
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/BackoffSpecTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/BackoffSpecTest.kt
@@ -1,0 +1,41 @@
+package com.tidal.sdk.tidalapi.networking
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BackoffSpecTest {
+
+    private val spec = BackoffSpec(baseMillis = 500L, maxMillis = 16_000L, maxRetries = 3)
+
+    @Test
+    fun `delay grows exponentially with jitter at the top of the band`() {
+        assertEquals(500L, spec.computeDelayMillis(attempt = 0) { 1.0 })
+        assertEquals(1000L, spec.computeDelayMillis(attempt = 1) { 1.0 })
+        assertEquals(2000L, spec.computeDelayMillis(attempt = 2) { 1.0 })
+    }
+
+    @Test
+    fun `delay is capped at maxMillis before jitter`() {
+        assertEquals(16_000L, spec.computeDelayMillis(attempt = 10) { 1.0 })
+    }
+
+    @Test
+    fun `jitter band lower edge scales the capped delay by 0_8`() {
+        assertEquals(400L, spec.computeDelayMillis(attempt = 0) { 0.0 })
+    }
+
+    @Test
+    fun `jitter band midpoint scales the capped delay by 0_9`() {
+        assertEquals(450L, spec.computeDelayMillis(attempt = 0) { 0.5 })
+    }
+
+    @Test
+    fun `jitter band upper edge scales the capped delay by 1_0`() {
+        assertEquals(500L, spec.computeDelayMillis(attempt = 0) { 1.0 })
+    }
+
+    @Test
+    fun `cap is applied before jitter so a capped delay still gets the lower band factor`() {
+        assertEquals(12_800L, spec.computeDelayMillis(attempt = 10) { 0.0 })
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
@@ -1,0 +1,77 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.net.SocketTimeoutException
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+import retrofit2.http.GET
+
+class RetrofitProviderRetryTest {
+
+    private lateinit var server: MockWebServer
+
+    private interface TestApi {
+        @GET("/ping") suspend fun ping(): Response<String>
+    }
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun api(
+        retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
+        readTimeoutMillis: Long = RetrofitProvider.DEFAULT_READ_TIMEOUT_MILLIS,
+    ): TestApi =
+        RetrofitProvider(retryPolicy = retryPolicy, readTimeoutMillis = readTimeoutMillis)
+            .provideRetrofit(server.url("/").toString(), FakeCredentialsProvider())
+            .create(TestApi::class.java)
+
+    @Test
+    fun `retries a GET by default until success`() = runTest {
+        // The default http-status backoff starts at 500ms, so a single retry costs ~0.5s wall
+        // clock.
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+
+        val response = api().ping()
+
+        assertEquals(200, response.code())
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `does not retry when the retry policy is null`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+
+        val response = api(retryPolicy = null).ping()
+
+        assertEquals(500, response.code())
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `the configured read timeout trips a SocketTimeoutException on a stalled read`() = runTest {
+        // Retry disabled so the timeout surfaces immediately (no 8s timeout-category backoff): a
+        // 200ms read timeout proves the configured value reaches the OkHttp client.
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val thrown = runCatching { api(retryPolicy = null, readTimeoutMillis = 200L).ping() }
+
+        assertInstanceOf(SocketTimeoutException::class.java, thrown.exceptionOrNull())
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifierTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifierTest.kt
@@ -1,0 +1,66 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class RetryClassifierTest {
+
+    private fun response(code: Int): Response =
+        Response.Builder()
+            .request(Request.Builder().url("https://example.com/").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("")
+            .build()
+
+    @Test
+    fun `SocketTimeoutException is a timeout`() {
+        assertEquals(
+            ErrorCategory.TIMEOUT,
+            classify(response = null, error = SocketTimeoutException()),
+        )
+    }
+
+    @Test
+    fun `other IOExceptions are network failures`() {
+        assertEquals(
+            ErrorCategory.NETWORK,
+            classify(response = null, error = UnknownHostException()),
+        )
+        assertEquals(ErrorCategory.NETWORK, classify(response = null, error = ConnectException()))
+        assertEquals(ErrorCategory.NETWORK, classify(response = null, error = SSLException("tls")))
+        assertEquals(ErrorCategory.NETWORK, classify(response = null, error = IOException("boom")))
+    }
+
+    @Test
+    fun `non-IOException throwables are not retryable`() {
+        assertNull(classify(response = null, error = RuntimeException("nope")))
+    }
+
+    @Test
+    fun `429 and 5xx responses are http-status failures`() {
+        assertEquals(ErrorCategory.HTTP_STATUS, classify(response(429), error = null))
+        assertEquals(ErrorCategory.HTTP_STATUS, classify(response(500), error = null))
+        assertEquals(ErrorCategory.HTTP_STATUS, classify(response(503), error = null))
+        assertEquals(ErrorCategory.HTTP_STATUS, classify(response(599), error = null))
+    }
+
+    @Test
+    fun `2xx, 3xx, 401 and non-429 4xx responses are not retryable`() {
+        assertNull(classify(response(200), error = null))
+        assertNull(classify(response(301), error = null))
+        assertNull(classify(response(400), error = null))
+        assertNull(classify(response(401), error = null))
+        assertNull(classify(response(403), error = null))
+        assertNull(classify(response(404), error = null))
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptorTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptorTest.kt
@@ -1,0 +1,268 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RetryInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private val recordedDelays = mutableListOf<Long>()
+    private val policy = DefaultRetryPolicy()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        recordedDelays.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun client(
+        retryPolicy: RetryPolicy = policy,
+        random: () -> Double = { 1.0 },
+        sleep: (Long) -> Unit = recordedDelays::add,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .readTimeout(200, TimeUnit.MILLISECONDS)
+            .addInterceptor(RetryInterceptor(retryPolicy, random, sleep))
+            .build()
+
+    private fun get() = Request.Builder().url(server.url("/")).build()
+
+    private fun head() = Request.Builder().url(server.url("/")).head().build()
+
+    private fun post() = Request.Builder().url(server.url("/")).post("body".toRequestBody()).build()
+
+    private fun patch() =
+        Request.Builder().url(server.url("/")).patch("body".toRequestBody()).build()
+
+    private fun delete() = Request.Builder().url(server.url("/")).delete().build()
+
+    @Test
+    fun `http-status category retries up to 3 then surfaces the last 5xx`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(4, server.requestCount)
+    }
+
+    @Test
+    fun `http-status category retries 503 until success`() {
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(3, server.requestCount)
+    }
+
+    @Test
+    fun `http-status category retries 429 until success`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `http-status backoff follows the capped curve at the top of the jitter band`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        client().newCall(get()).execute()
+
+        // base 500ms, cap 16s: 500, 1000, 2000 (× jitter 1.0).
+        assertEquals(listOf(500L, 1000L, 2000L), recordedDelays)
+    }
+
+    @Test
+    fun `network category retries up to 10 on a non-timeout IOException`() {
+        repeat(11) {
+            server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+        assertEquals(11, server.requestCount)
+    }
+
+    @Test
+    fun `network category recovers when a success arrives before exhaustion`() {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `network backoff grows toward the 16s cap`() {
+        repeat(11) {
+            server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+
+        // base 1s, cap 16s: 1000, 2000, 4000, 8000, 16000, then clamped at 16000 (× jitter 1.0).
+        assertEquals(
+            listOf(
+                1000L,
+                2000L,
+                4000L,
+                8000L,
+                16_000L,
+                16_000L,
+                16_000L,
+                16_000L,
+                16_000L,
+                16_000L,
+            ),
+            recordedDelays,
+        )
+    }
+
+    @Test
+    fun `timeout category retries up to 3 on a SocketTimeoutException`() {
+        repeat(4) { server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)) }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+        assertEquals(4, server.requestCount)
+        // base 8s, cap 32s: 8000, 16000, 32000 (× jitter 1.0).
+        assertEquals(listOf(8_000L, 16_000L, 32_000L), recordedDelays)
+    }
+
+    @Test
+    fun `independent per-category counts let a network error retry after timeouts`() {
+        repeat(3) { server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)) }
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        // 3 timeouts (exhausting timeout N=3) + 1 network failure + success: timeout budget spent
+        // does not block the still-available network budget.
+        assertEquals(5, server.requestCount)
+    }
+
+    @Test
+    fun `HEAD is retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(head()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `POST is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(post()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `PATCH is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(patch()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `DELETE is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(delete()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `401 is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(401, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `non-429 4xx is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(404, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `a successful response is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `an interrupted backoff stops retrying, restores the interrupt flag and surfaces an IOException`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+        val interrupting = client(sleep = { throw InterruptedException("interrupted") })
+
+        assertThrows(IOException::class.java) { interrupting.newCall(get()).execute() }
+        assertEquals(1, server.requestCount)
+        assertTrue(Thread.interrupted())
+    }
+
+    @Test
+    fun `a call cancelled during backoff stops retrying and surfaces an IOException`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+        lateinit var call: Call
+        val cancelling = client(sleep = { call.cancel() })
+        call = cancelling.newCall(get())
+
+        assertThrows(IOException::class.java) { call.execute() }
+        assertEquals(1, server.requestCount)
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicyTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicyTest.kt
@@ -1,0 +1,56 @@
+package com.tidal.sdk.tidalapi.networking
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RetryPolicyTest {
+
+    private val policy = DefaultRetryPolicy()
+
+    @Test
+    fun `DefaultRetryPolicy exposes the http-status constants`() {
+        assertEquals(
+            BackoffSpec(baseMillis = 500L, maxMillis = 16_000L, maxRetries = 3),
+            policy.httpStatus,
+        )
+    }
+
+    @Test
+    fun `DefaultRetryPolicy exposes the timeout constants`() {
+        assertEquals(
+            BackoffSpec(baseMillis = 8_000L, maxMillis = 32_000L, maxRetries = 3),
+            policy.timeout,
+        )
+    }
+
+    @Test
+    fun `DefaultRetryPolicy exposes the network constants`() {
+        assertEquals(
+            BackoffSpec(baseMillis = 1_000L, maxMillis = 16_000L, maxRetries = 10),
+            policy.network,
+        )
+    }
+
+    @Test
+    fun `specFor returns the matching BackoffSpec per category`() {
+        assertEquals(policy.httpStatus, policy.specFor(ErrorCategory.HTTP_STATUS))
+        assertEquals(policy.timeout, policy.specFor(ErrorCategory.TIMEOUT))
+        assertEquals(policy.network, policy.specFor(ErrorCategory.NETWORK))
+    }
+
+    @Test
+    fun `isRetryableRequest allows GET and HEAD without a key`() {
+        assertTrue(policy.isRetryableRequest("GET", hasIdempotencyKey = false))
+        assertTrue(policy.isRetryableRequest("HEAD", hasIdempotencyKey = false))
+    }
+
+    @Test
+    fun `isRetryableRequest rejects mutations even with a key (Step 1 ignores the key)`() {
+        assertFalse(policy.isRetryableRequest("POST", hasIdempotencyKey = false))
+        assertFalse(policy.isRetryableRequest("POST", hasIdempotencyKey = true))
+        assertFalse(policy.isRetryableRequest("PATCH", hasIdempotencyKey = true))
+        assertFalse(policy.isRetryableRequest("DELETE", hasIdempotencyKey = true))
+    }
+}


### PR DESCRIPTION
## Why

The `tidalapi` module has no retry — transient backend failures (5xx, 429, timeouts, dropped connections) surface straight to callers. TIDE-1891 defines a standard HTTP retry mechanism (ported from the iOS player SDK). This implements it for read calls.

## What

- Add an OkHttp `RetryInterceptor` in `RetrofitProvider`, below Retrofit's type layer, so the `Response<T>` consumer contract is unchanged.
- Three error categories with independent per-category attempt counts and backoff:
  - HTTP status (429 / 5xx): base 500ms, cap 16s, 3 retries
  - Timeout (`SocketTimeoutException`): base 8s, cap 32s, 3 retries
  - Network (other `IOException`): base 1s, cap 16s, 10 retries
- Backoff `D = min(B·2ⁿ, M)` then `× j`, `j ∈ [0.8, 1.0]` (cap-then-jitter, matching iOS).
- Retry GET/HEAD only; 401 left to `DefaultAuthenticator`; non-429 4xx not retried.
- Set a configurable ~5s read timeout on the client. Default-on; `retryPolicy = null` disables.

## How to test

- `./gradlew :tidalapi:test` — covers per-category counts (3 / 3 / 10), backoff + jitter band, max-delay cap, GET/HEAD retried, writes not retried, 401 not retried, retries exhausted, read timeout configured, and disable.
- `./gradlew :tidalapi:assemble` and `./static-analysis/run-detekt.sh` clean.

## Risk Assessment

Medium — changes default network behavior for all tidalapi reads (adds retries and lowers the read timeout to ~5s). Scoped to GET/HEAD, sits below Retrofit's type layer, and is fully disable-able via the `RetrofitProvider` constructor. The 5s read-timeout value is still pending confirmation with the spec author (spec says 4–5s; iOS currently runs 15s).

Writes and idempotency are out of scope — follow-up TM-1415.
