### PR TITLE
TM-1414 Add RetryClassifier mapping responses and exceptions to retry categories

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifier.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifier.kt
@@ -1,0 +1,34 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import okhttp3.Response
+
+private const val TOO_MANY_REQUESTS = 429
+private const val SERVER_ERROR_MIN = 500
+private const val SERVER_ERROR_MAX = 599
+
+/**
+ * The [ErrorCategory] this response represents for retry purposes, or `null` when it is not
+ * retryable. Only code 429 or a 5xx is an [HTTP_STATUS][ErrorCategory.HTTP_STATUS] failure;
+ * 2xx/3xx, 401 (left to [DefaultAuthenticator]) and every other 4xx are deliberately non-retryable.
+ */
+internal fun Response.toRetryCategory(): ErrorCategory? =
+    if (code == TOO_MANY_REQUESTS || code in SERVER_ERROR_MIN..SERVER_ERROR_MAX) {
+        ErrorCategory.HTTP_STATUS
+    } else {
+        null
+    }
+
+/**
+ * The [ErrorCategory] this throwable represents for retry purposes, or `null` when it is not
+ * retryable. A [SocketTimeoutException] is a [TIMEOUT][ErrorCategory.TIMEOUT]; any other
+ * [IOException] is a [NETWORK][ErrorCategory.NETWORK] failure (DNS, TLS, connection, …). A
+ * non-[IOException] throwable is never retried (it is rethrown by the caller).
+ */
+internal fun Throwable.toRetryCategory(): ErrorCategory? =
+    when (this) {
+        is SocketTimeoutException -> ErrorCategory.TIMEOUT
+        is IOException -> ErrorCategory.NETWORK
+        else -> null
+    }


### PR DESCRIPTION
## Why
The interceptor needs to map a response or a thrown error to the category that governs its retry.

## What
- Add `Response.toRetryCategory()` — `429` or `5xx` → `HTTP_STATUS`, otherwise not retryable.
- Add `Throwable.toRetryCategory()` — `SocketTimeoutException` → `TIMEOUT`, other `IOException` → `NETWORK`, otherwise not retryable.

## How to test
`./gradlew :tidalapi:test` — `RetryClassifierTest` covers status codes (incl. 401 / non-429 4xx as non-retryable) and exception types.

## Risk Assessment
Low — pure mapping functions; not wired into any request path yet.

Part of TM-1414 (tidalapi read-call retry).
