### PR TITLE
TM-1414 Add tests for tidalapi three-category retry (reads only)

### DIFF
--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/BackoffConfigurationTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/BackoffConfigurationTest.kt
@@ -1,0 +1,74 @@
+package com.tidal.sdk.tidalapi.networking
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BackoffConfigurationTest {
+
+    private val baseMillis = 500L
+    private val maxMillis = 16_000L
+    private val configuration =
+        BackoffConfiguration(baseMillis = baseMillis, maxMillis = maxMillis, maxRetries = 3)
+
+    // computeDelayMillis multiplies the (capped) delay by 0.8 + 0.2 * random(), so the random
+    // source's [0.0, 1.0] range maps onto the [0.8, 1.0] jitter band.
+    private val jitterLowEdge = { 0.0 } // factor 0.8
+    private val jitterMidpoint = { 0.5 } // factor 0.9
+    private val jitterHighEdge = { 1.0 } // factor 1.0
+
+    @Test
+    fun `delay grows exponentially with jitter at the top of the band`() {
+        assertEquals(
+            baseMillis,
+            configuration.computeDelayMillis(attempt = 0, random = jitterHighEdge),
+        )
+        assertEquals(
+            baseMillis * 2,
+            configuration.computeDelayMillis(attempt = 1, random = jitterHighEdge),
+        )
+        assertEquals(
+            baseMillis * 4,
+            configuration.computeDelayMillis(attempt = 2, random = jitterHighEdge),
+        )
+    }
+
+    @Test
+    fun `delay is capped at maxMillis before jitter`() {
+        assertEquals(
+            maxMillis,
+            configuration.computeDelayMillis(attempt = 10, random = jitterHighEdge),
+        )
+    }
+
+    @Test
+    fun `jitter band lower edge scales the capped delay by 0_8`() {
+        assertEquals(
+            (baseMillis * 0.8).toLong(),
+            configuration.computeDelayMillis(attempt = 0, random = jitterLowEdge),
+        )
+    }
+
+    @Test
+    fun `jitter band midpoint scales the capped delay by 0_9`() {
+        assertEquals(
+            (baseMillis * 0.9).toLong(),
+            configuration.computeDelayMillis(attempt = 0, random = jitterMidpoint),
+        )
+    }
+
+    @Test
+    fun `jitter band upper edge scales the capped delay by 1_0`() {
+        assertEquals(
+            baseMillis,
+            configuration.computeDelayMillis(attempt = 0, random = jitterHighEdge),
+        )
+    }
+
+    @Test
+    fun `cap is applied before jitter so a capped delay still gets the lower band factor`() {
+        assertEquals(
+            (maxMillis * 0.8).toLong(),
+            configuration.computeDelayMillis(attempt = 10, random = jitterLowEdge),
+        )
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
@@ -1,0 +1,85 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.net.SocketTimeoutException
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+import retrofit2.http.GET
+
+class RetrofitProviderRetryTest {
+
+    private lateinit var server: MockWebServer
+
+    private interface TestApi {
+        @GET("/ping") suspend fun ping(): Response<String>
+    }
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun api(
+        retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
+        readTimeoutMillis: Long = RetrofitProvider.DEFAULT_READ_TIMEOUT_MILLIS,
+    ): TestApi =
+        RetrofitProvider(retryPolicy = retryPolicy, readTimeoutMillis = readTimeoutMillis)
+            .provideRetrofit(server.url("/").toString(), FakeCredentialsProvider())
+            .create(TestApi::class.java)
+
+    @Test
+    fun `retries a GET by default until success`() = runTest {
+        // The default http-status backoff starts at 500ms, so a single retry costs ~0.5s wall
+        // clock.
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+
+        val response = api().ping()
+
+        assertEquals(200, response.code())
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `does not retry when the retry policy is null`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+
+        val response = api(retryPolicy = null).ping()
+
+        assertEquals(500, response.code())
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `the configured read timeout trips a SocketTimeoutException on a stalled read`() = runTest {
+        // Retry disabled so the timeout surfaces immediately (no 8s timeout-category backoff): a
+        // 200ms read timeout proves the configured value reaches the OkHttp client.
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+
+        val thrown = runCatching { api(retryPolicy = null, readTimeoutMillis = 200L).ping() }
+
+        assertInstanceOf(SocketTimeoutException::class.java, thrown.exceptionOrNull())
+    }
+
+    @Test
+    fun `rejects a non-positive read timeout`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            RetrofitProvider(readTimeoutMillis = 0)
+        }
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifierTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryClassifierTest.kt
@@ -1,0 +1,60 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLException
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class RetryClassifierTest {
+
+    private fun response(code: Int): Response =
+        Response.Builder()
+            .request(Request.Builder().url("https://example.com/").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("")
+            .build()
+
+    @Test
+    fun `SocketTimeoutException is a timeout`() {
+        assertEquals(ErrorCategory.TIMEOUT, SocketTimeoutException().toRetryCategory())
+    }
+
+    @Test
+    fun `other IOExceptions are network failures`() {
+        assertEquals(ErrorCategory.NETWORK, UnknownHostException().toRetryCategory())
+        assertEquals(ErrorCategory.NETWORK, ConnectException().toRetryCategory())
+        assertEquals(ErrorCategory.NETWORK, SSLException("tls").toRetryCategory())
+        assertEquals(ErrorCategory.NETWORK, IOException("boom").toRetryCategory())
+    }
+
+    @Test
+    fun `non-IOException throwables are not retryable`() {
+        assertNull(RuntimeException("nope").toRetryCategory())
+    }
+
+    @Test
+    fun `429 and 5xx responses are http-status failures`() {
+        assertEquals(ErrorCategory.HTTP_STATUS, response(429).toRetryCategory())
+        assertEquals(ErrorCategory.HTTP_STATUS, response(500).toRetryCategory())
+        assertEquals(ErrorCategory.HTTP_STATUS, response(503).toRetryCategory())
+        assertEquals(ErrorCategory.HTTP_STATUS, response(599).toRetryCategory())
+    }
+
+    @Test
+    fun `2xx, 3xx, 401 and non-429 4xx responses are not retryable`() {
+        assertNull(response(200).toRetryCategory())
+        assertNull(response(301).toRetryCategory())
+        assertNull(response(400).toRetryCategory())
+        assertNull(response(401).toRetryCategory())
+        assertNull(response(403).toRetryCategory())
+        assertNull(response(404).toRetryCategory())
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptorTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptorTest.kt
@@ -1,0 +1,268 @@
+package com.tidal.sdk.tidalapi.networking
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RetryInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private val recordedDelays = mutableListOf<Long>()
+    private val policy = DefaultRetryPolicy()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        recordedDelays.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun client(
+        retryPolicy: RetryPolicy = policy,
+        random: () -> Double = { 1.0 },
+        sleep: (Long) -> Unit = recordedDelays::add,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .readTimeout(200, TimeUnit.MILLISECONDS)
+            .addInterceptor(RetryInterceptor(retryPolicy, random, sleep))
+            .build()
+
+    private fun get() = Request.Builder().url(server.url("/")).build()
+
+    private fun head() = Request.Builder().url(server.url("/")).head().build()
+
+    private fun post() = Request.Builder().url(server.url("/")).post("body".toRequestBody()).build()
+
+    private fun patch() =
+        Request.Builder().url(server.url("/")).patch("body".toRequestBody()).build()
+
+    private fun delete() = Request.Builder().url(server.url("/")).delete().build()
+
+    @Test
+    fun `http-status category retries up to 3 then surfaces the last 5xx`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(4, server.requestCount)
+    }
+
+    @Test
+    fun `http-status category retries 503 until success`() {
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(503))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(3, server.requestCount)
+    }
+
+    @Test
+    fun `http-status category retries 429 until success`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `http-status backoff follows the capped curve at the top of the jitter band`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        client().newCall(get()).execute()
+
+        // base 500ms, cap 16s: 500, 1000, 2000 (× jitter 1.0).
+        assertEquals(listOf(500L, 1000L, 2000L), recordedDelays)
+    }
+
+    @Test
+    fun `network category retries up to 10 on a non-timeout IOException`() {
+        repeat(11) {
+            server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+        assertEquals(11, server.requestCount)
+    }
+
+    @Test
+    fun `network category recovers when a success arrives before exhaustion`() {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `network backoff grows toward the 16s cap`() {
+        repeat(11) {
+            server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+
+        // base 1s, cap 16s: 1000, 2000, 4000, 8000, 16000, then clamped at 16000 (× jitter 1.0).
+        assertEquals(
+            listOf(
+                1000L,
+                2000L,
+                4000L,
+                8000L,
+                16_000L,
+                16_000L,
+                16_000L,
+                16_000L,
+                16_000L,
+                16_000L,
+            ),
+            recordedDelays,
+        )
+    }
+
+    @Test
+    fun `timeout category retries up to 3 on a SocketTimeoutException`() {
+        repeat(4) { server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)) }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+        assertEquals(4, server.requestCount)
+        // base 8s, cap 32s: 8000, 16000, 32000 (× jitter 1.0).
+        assertEquals(listOf(8_000L, 16_000L, 32_000L), recordedDelays)
+    }
+
+    @Test
+    fun `independent per-category counts let a network error retry after timeouts`() {
+        repeat(3) { server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)) }
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        // 3 timeouts (exhausting timeout N=3) + 1 network failure + success: timeout budget spent
+        // does not block the still-available network budget.
+        assertEquals(5, server.requestCount)
+    }
+
+    @Test
+    fun `HEAD is retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(head()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+    }
+
+    @Test
+    fun `POST is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(post()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `PATCH is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(patch()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `DELETE is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(delete()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `401 is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(401, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `non-429 4xx is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(404, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `a successful response is not retried`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `an interrupted backoff stops retrying, restores the interrupt flag and surfaces an IOException`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+        val interrupting = client(sleep = { throw InterruptedException("interrupted") })
+
+        assertThrows(IOException::class.java) { interrupting.newCall(get()).execute() }
+        assertEquals(1, server.requestCount)
+        assertTrue(Thread.interrupted())
+    }
+
+    @Test
+    fun `a call cancelled during backoff stops retrying and surfaces an IOException`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+        lateinit var call: Call
+        val cancelling = client(sleep = { call.cancel() })
+        call = cancelling.newCall(get())
+
+        assertThrows(IOException::class.java) { call.execute() }
+        assertEquals(1, server.requestCount)
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicyTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicyTest.kt
@@ -1,0 +1,56 @@
+package com.tidal.sdk.tidalapi.networking
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RetryPolicyTest {
+
+    private val policy = DefaultRetryPolicy()
+
+    @Test
+    fun `DefaultRetryPolicy exposes the http-status constants`() {
+        assertEquals(
+            BackoffConfiguration(baseMillis = 500L, maxMillis = 16_000L, maxRetries = 3),
+            policy.httpStatus,
+        )
+    }
+
+    @Test
+    fun `DefaultRetryPolicy exposes the timeout constants`() {
+        assertEquals(
+            BackoffConfiguration(baseMillis = 8_000L, maxMillis = 32_000L, maxRetries = 3),
+            policy.timeout,
+        )
+    }
+
+    @Test
+    fun `DefaultRetryPolicy exposes the network constants`() {
+        assertEquals(
+            BackoffConfiguration(baseMillis = 1_000L, maxMillis = 16_000L, maxRetries = 10),
+            policy.network,
+        )
+    }
+
+    @Test
+    fun `getConfigurationFor returns the matching configuration per category`() {
+        assertEquals(policy.httpStatus, policy.getConfigurationFor(ErrorCategory.HTTP_STATUS))
+        assertEquals(policy.timeout, policy.getConfigurationFor(ErrorCategory.TIMEOUT))
+        assertEquals(policy.network, policy.getConfigurationFor(ErrorCategory.NETWORK))
+    }
+
+    @Test
+    fun `isRetryableRequest allows GET, HEAD and OPTIONS`() {
+        assertTrue(policy.isRetryableRequest("GET"))
+        assertTrue(policy.isRetryableRequest("HEAD"))
+        assertTrue(policy.isRetryableRequest("OPTIONS"))
+    }
+
+    @Test
+    fun `isRetryableRequest rejects mutations`() {
+        assertFalse(policy.isRetryableRequest("POST"))
+        assertFalse(policy.isRetryableRequest("PATCH"))
+        assertFalse(policy.isRetryableRequest("DELETE"))
+    }
+}


### PR DESCRIPTION
## Why
Lock in the retry behaviour so it can't regress.

## What
- Add the unit tests for the backoff math and jitter, the policy constants and method eligibility, the response/exception classification, the interceptor's per-category retry/backoff/cancellation behaviour, and the provider wiring plus the read-timeout guard.

## How to test
`./gradlew :tidalapi:test` (all green); `./static-analysis/run-detekt.sh` clean.

## Risk Assessment
Low — tests only.

Part of TM-1414 (tidalapi read-call retry).
