### PR TITLE
Switch tidalapi generator to the 7.23.0 minimal fork (jar + config)

### DIFF
--- a/tidalapi/openapi-config/openapi-config.yml
+++ b/tidalapi/openapi-config/openapi-config.yml
@@ -7,7 +7,8 @@ globalProperties:
 additionalProperties:
   artifactId: tidalapi.generated
   packageName: com.tidal.sdk.tidalapi.generated
-  apiSuffix: ''
+  apiNameSuffix: ''
+  removeEnumValuePrefix: true
   groupId: com.tidal.sdk
   library: jvm-retrofit2
   serializationLibrary: kotlinx_serialization


### PR DESCRIPTION
My original plan was to get us fully onto the official openapi-generator release. However, as it turns out, that would need a small API change, but that change would break the other platforms' generators. Because of that, I opted for just updating the fork, which this PR is about.
There are much fewer changes in the codebase and it's tested. However, I opted not to package the regenerated API  code into this PR.

## Why

The `tidalapi` module generates its client from the TIDAL OpenAPI spec using a fork of `openapi-generator` pinned at `7.10.0-SNAPSHOT` (13 versions behind upstream). That fork has been rebased onto the official `7.23.0` release as a minimal delta (see `tidal-music/openapi-generator` PR #2) — this swaps the SDK over to it.

## What

- Replace `tidalapi/bin/openapi-generator-cli.jar` with a `7.23.0` build of the minimal fork.
- Fix the generator config so regeneration keeps the current names:
  - `apiNameSuffix: ''` — the old `apiSuffix: ''` was an unrecognized key for the kotlin generator (the real option is `apiNameSuffix`, default `"Api"`), so without this the API interfaces would be renamed (`Albums` → `AlbumsApi`).
  - `removeEnumValuePrefix: true` — restores the stripped enum constant names (e.g. `PreviewReason.SUBSCRIPTION`), which default to off in `7.23.0`. Wire values via `@SerialName` are unchanged.

This PR intentionally contains **only** the generator + config. No regenerated code, version bump, or changelog entry — regenerating the module is a separate step.

## Risk Assessment

Low — this changes only the generator tooling and its config. No generated or hand-written sources change here, so the module compiles exactly as on `main`. Verified locally that regenerating with this jar + config produces no breaking renames (API interface and enum names unchanged) and that the regenerated module passes `:tidalapi:assemble` and `:tidalapi:test`.

## References

- Fork PR: tidal-music/openapi-generator#2
- TM-1216