### PR TITLE
TIDE-1931 Skip player retry for TRACK/VIDEO PlaybackInfo fetches

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/NoRetryLoadErrorHandlingPolicy.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/NoRetryLoadErrorHandlingPolicy.kt
@@ -1,0 +1,18 @@
+package com.tidal.sdk.player.playbackengine
+
+import androidx.media3.common.C
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy.LoadErrorInfo
+
+/**
+ * A [LoadErrorHandlingPolicy] that never retries the load it governs: [getRetryDelayMsFor] always
+ * returns [C.TIME_UNSET], so PlaybackInfoLoadableLoaderCallback.onLoadError treats every load error
+ * as fatal. Used for TIDAL API-backed (TRACK/VIDEO) PlaybackInfo fetches, whose retry is owned by
+ * tidalapi's built-in retry. All other policy methods delegate to [loadErrorHandlingPolicy].
+ */
+internal class NoRetryLoadErrorHandlingPolicy(
+    private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy
+) : LoadErrorHandlingPolicy by loadErrorHandlingPolicy {
+
+    override fun getRetryDelayMsFor(loadErrorInfo: LoadErrorInfo) = C.TIME_UNSET
+}

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSource.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSource.kt
@@ -43,6 +43,7 @@ internal class PlaybackInfoMediaSource(
     private val loaderCallback by lazy {
         loaderCallbackFactory.create(
             mediaItem,
+            loadErrorHandlingPolicy,
             dataType,
             eventDispatcher,
             loadEventInfoF,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceFactory.kt
@@ -10,6 +10,7 @@ import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.Loader
 import com.tidal.sdk.player.common.ForwardingMediaProduct
 import com.tidal.sdk.player.common.model.MediaProduct
+import com.tidal.sdk.player.common.model.ProductType
 import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadableFactory
 import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadableLoaderCallbackFactory
 import com.tidal.sdk.player.playbackengine.mediasource.streamingsession.StreamingSession
@@ -18,7 +19,8 @@ private const val DATA_TYPE = C.DATA_TYPE_MANIFEST
 private const val LOADER_THREAD_NAME_SUFFIX = "PlaybackInfoMediaSource"
 
 internal class PlaybackInfoMediaSourceFactory(
-    private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
+    private val playerLoadErrorHandlingPolicy: LoadErrorHandlingPolicy,
+    private val noRetryLoadErrorHandlingPolicy: LoadErrorHandlingPolicy,
     private val playbackInfoLoadableFactory: PlaybackInfoLoadableFactory,
     private val playbackInfoLoadableLoaderCallbackFactory:
         PlaybackInfoLoadableLoaderCallbackFactory, // ktlint-disable max-line-length
@@ -28,8 +30,15 @@ internal class PlaybackInfoMediaSourceFactory(
     fun create(
         streamingSession: StreamingSession,
         forwardingMediaProduct: ForwardingMediaProduct<MediaProduct>,
-    ) =
-        PlaybackInfoMediaSource(
+    ): PlaybackInfoMediaSource {
+        val loadErrorHandlingPolicy =
+            when (forwardingMediaProduct.productType) {
+                ProductType.TRACK,
+                ProductType.VIDEO -> noRetryLoadErrorHandlingPolicy
+                ProductType.BROADCAST,
+                ProductType.UC -> playerLoadErrorHandlingPolicy
+            }
+        return PlaybackInfoMediaSource(
             forwardingMediaProduct,
             loadErrorHandlingPolicy,
             playbackInfoLoadableFactory.create(streamingSession, forwardingMediaProduct),
@@ -61,4 +70,5 @@ internal class PlaybackInfoMediaSourceFactory(
             playbackInfoLoadableLoaderCallbackFactory,
             forwardingMediaProduct.extras,
         )
+    }
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallbackFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/mediasource/loadable/PlaybackInfoLoadableLoaderCallbackFactory.kt
@@ -10,13 +10,13 @@ import com.tidal.sdk.player.playbackengine.mediasource.TidalMediaSourceCreator
 import java.io.IOException
 
 internal class PlaybackInfoLoadableLoaderCallbackFactory(
-    private val tidalMediaSourceCreator: TidalMediaSourceCreator,
-    private val loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
+    private val tidalMediaSourceCreator: TidalMediaSourceCreator
 ) {
 
     @Suppress("LongParameterList")
     fun create(
         mediaItem: MediaItem,
+        loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
         dataType: Int,
         eventDispatcher: MediaSourceEventListener.EventDispatcher,
         loadEventInfoF: (Long, Long) -> LoadEventInfo,

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
@@ -26,6 +26,7 @@ import com.tidal.sdk.player.commonandroid.Base64Codec
 import com.tidal.sdk.player.commonandroid.TrueTimeWrapper
 import com.tidal.sdk.player.events.EventReporter
 import com.tidal.sdk.player.playbackengine.Encryption
+import com.tidal.sdk.player.playbackengine.NoRetryLoadErrorHandlingPolicy
 import com.tidal.sdk.player.playbackengine.PlayerLoadErrorHandlingPolicy
 import com.tidal.sdk.player.playbackengine.StreamingApiRepository
 import com.tidal.sdk.player.playbackengine.TidalExtractorsFactory
@@ -174,6 +175,13 @@ internal object MediaSourcererModule {
     internal fun providePlayerLoadErrorHandlingPolicy(
         @Named("defaultLoadErrorHandlingPolicy") loadErrorHandlingPolicy: LoadErrorHandlingPolicy
     ): LoadErrorHandlingPolicy = PlayerLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+
+    @Provides
+    @Reusable
+    @Named("noRetryLoadErrorHandlingPolicy")
+    fun provideNoRetryLoadErrorHandlingPolicy(
+        @Named("defaultLoadErrorHandlingPolicy") loadErrorHandlingPolicy: LoadErrorHandlingPolicy
+    ): LoadErrorHandlingPolicy = NoRetryLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
 
     @Provides
     @Reusable
@@ -469,19 +477,21 @@ internal object MediaSourcererModule {
     @Provides
     @Reusable
     fun playbackInfoLoadableLoaderCallbackFactory(
-        tidalMediaSourceCreator: TidalMediaSourceCreator,
-        loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
-    ) = PlaybackInfoLoadableLoaderCallbackFactory(tidalMediaSourceCreator, loadErrorHandlingPolicy)
+        tidalMediaSourceCreator: TidalMediaSourceCreator
+    ) = PlaybackInfoLoadableLoaderCallbackFactory(tidalMediaSourceCreator)
 
     @Provides
     @Reusable
     fun playbackInfoMediaSourceFactory(
         loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
+        @Named("noRetryLoadErrorHandlingPolicy")
+        noRetryLoadErrorHandlingPolicy: LoadErrorHandlingPolicy,
         playbackInfoLoadableFactory: PlaybackInfoLoadableFactory,
         playbackInfoLoadableLoaderCallbackFactory: PlaybackInfoLoadableLoaderCallbackFactory,
     ) =
         PlaybackInfoMediaSourceFactory(
             loadErrorHandlingPolicy,
+            noRetryLoadErrorHandlingPolicy,
             playbackInfoLoadableFactory,
             playbackInfoLoadableLoaderCallbackFactory,
         )

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/NoRetryLoadErrorHandlingPolicyTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/NoRetryLoadErrorHandlingPolicyTest.kt
@@ -1,0 +1,42 @@
+package com.tidal.sdk.player.playbackengine
+
+import androidx.media3.common.C
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy.LoadErrorInfo
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import java.io.IOException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoMoreInteractions
+
+internal class NoRetryLoadErrorHandlingPolicyTest {
+
+    private val loadErrorHandlingPolicy = mock<LoadErrorHandlingPolicy>()
+    private val noRetryLoadErrorHandlingPolicy =
+        NoRetryLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+
+    @AfterEach fun afterEach() = verifyNoMoreInteractions(loadErrorHandlingPolicy)
+
+    @Test
+    fun getRetryDelayMsForReturnsTimeUnsetForArbitraryLoadErrorInfo() {
+        val loadErrorInfo = LoadErrorInfo(mock(), mock(), IOException(), 1)
+
+        val actualRetryDelayMs = noRetryLoadErrorHandlingPolicy.getRetryDelayMsFor(loadErrorInfo)
+
+        assertThat(actualRetryDelayMs).isEqualTo(C.TIME_UNSET)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [-1, 0, 1, 2, 3, 4, 5, 10])
+    fun getRetryDelayMsForReturnsTimeUnsetRegardlessOfErrorCount(errorCount: Int) {
+        val loadErrorInfo = LoadErrorInfo(mock(), mock(), IOException(), errorCount)
+
+        val actualRetryDelayMs = noRetryLoadErrorHandlingPolicy.getRetryDelayMsFor(loadErrorInfo)
+
+        assertThat(actualRetryDelayMs).isEqualTo(C.TIME_UNSET)
+    }
+}

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceExtensions.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceExtensions.kt
@@ -2,8 +2,12 @@ package com.tidal.sdk.player.playbackengine.mediasource
 
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.MediaSourceEventListener.EventDispatcher
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import com.tidal.sdk.player.reflectionGetInstanceMemberProperty
 import com.tidal.sdk.player.reflectionSetInstanceMemberProperty
+
+internal val PlaybackInfoMediaSource.reflectionLoadErrorHandlingPolicy: LoadErrorHandlingPolicy
+    get() = reflectionGetInstanceMemberProperty("loadErrorHandlingPolicy")!!
 
 internal val PlaybackInfoMediaSource.reflectionEventDispatcher: EventDispatcher
     get() = reflectionGetInstanceMemberProperty("eventDispatcher")!!

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceFactoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceFactoryTest.kt
@@ -1,0 +1,91 @@
+package com.tidal.sdk.player.playbackengine.mediasource
+
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+import assertk.assertThat
+import assertk.assertions.isSameInstanceAs
+import com.tidal.sdk.player.common.ForwardingMediaProduct
+import com.tidal.sdk.player.common.model.MediaProduct
+import com.tidal.sdk.player.common.model.ProductType
+import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadable
+import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadableFactory
+import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoadableLoaderCallbackFactory
+import com.tidal.sdk.player.playbackengine.mediasource.streamingsession.StreamingSession
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal class PlaybackInfoMediaSourceFactoryTest {
+
+    private val playerLoadErrorHandlingPolicy = mock<LoadErrorHandlingPolicy>()
+    private val noRetryLoadErrorHandlingPolicy = mock<LoadErrorHandlingPolicy>()
+    private val playbackInfoLoadableFactory = mock<PlaybackInfoLoadableFactory>()
+    private val playbackInfoLoadableLoaderCallbackFactory =
+        mock<PlaybackInfoLoadableLoaderCallbackFactory>()
+    private val playbackInfoMediaSourceFactory =
+        PlaybackInfoMediaSourceFactory(
+            playerLoadErrorHandlingPolicy,
+            noRetryLoadErrorHandlingPolicy,
+            playbackInfoLoadableFactory,
+            playbackInfoLoadableLoaderCallbackFactory,
+        )
+
+    /**
+     * Asserts the policy selected per product type. Combined with
+     * NoRetryLoadErrorHandlingPolicyTest (no-retry policy returns C.TIME_UNSET),
+     * PlaybackInfoLoadableLoaderCallbackTest (C.TIME_UNSET -> DONT_RETRY_FATAL), and
+     * PlayerLoadErrorHandlingPolicyTest (player policy retries 5xx/429), this proves TRACK/VIDEO
+     * PlaybackInfo fetches are fatal on first error while BROADCAST/UC still retry.
+     */
+    @ParameterizedTest
+    @MethodSource("productTypeToExpectedPolicy")
+    fun createSelectsPolicyForProductType(
+        productType: ProductType,
+        expectedPolicyIsNoRetry: Boolean,
+    ) {
+        val streamingSession = mock<StreamingSession.Explicit>()
+        val forwardingMediaProduct = ForwardingMediaProduct(MediaProduct(productType, "123"))
+        whenever(playbackInfoLoadableFactory.create(streamingSession, forwardingMediaProduct))
+            .thenReturn(mock<PlaybackInfoLoadable>())
+
+        val playbackInfoMediaSource =
+            playbackInfoMediaSourceFactory.create(streamingSession, forwardingMediaProduct)
+
+        val expectedPolicy =
+            if (expectedPolicyIsNoRetry) {
+                noRetryLoadErrorHandlingPolicy
+            } else {
+                playerLoadErrorHandlingPolicy
+            }
+        assertThat(playbackInfoMediaSource.reflectionLoadErrorHandlingPolicy)
+            .isSameInstanceAs(expectedPolicy)
+    }
+
+    @Test
+    fun createForwardsMediaProduct() {
+        val streamingSession = mock<StreamingSession.Explicit>()
+        val forwardingMediaProduct = ForwardingMediaProduct(MediaProduct(ProductType.TRACK, "123"))
+        whenever(playbackInfoLoadableFactory.create(streamingSession, forwardingMediaProduct))
+            .thenReturn(mock<PlaybackInfoLoadable>())
+
+        val playbackInfoMediaSource =
+            playbackInfoMediaSourceFactory.create(streamingSession, forwardingMediaProduct)
+
+        assertThat(playbackInfoMediaSource.forwardingMediaProduct)
+            .isSameInstanceAs(forwardingMediaProduct)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun productTypeToExpectedPolicy() =
+            listOf(
+                Arguments.of(ProductType.TRACK, true),
+                Arguments.of(ProductType.VIDEO, true),
+                Arguments.of(ProductType.BROADCAST, false),
+                Arguments.of(ProductType.UC, false),
+            )
+    }
+}

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/mediasource/PlaybackInfoMediaSourceTest.kt
@@ -83,6 +83,7 @@ internal class PlaybackInfoMediaSourceTest {
         whenever(
                 callbackFactory.create(
                     expectedMediaItem,
+                    loadErrorHandlingPolicy,
                     C.DATA_TYPE_MANIFEST,
                     eventDispatcher,
                     loadEventInfoF,
@@ -129,6 +130,7 @@ internal class PlaybackInfoMediaSourceTest {
         whenever(
                 callbackFactory.create(
                     expectedMediaItem,
+                    loadErrorHandlingPolicy,
                     C.DATA_TYPE_MANIFEST,
                     playbackInfoMediaSource.reflectionEventDispatcher,
                     loadEventInfoF,
@@ -156,6 +158,7 @@ internal class PlaybackInfoMediaSourceTest {
         whenever(
                 callbackFactory.create(
                     expectedMediaItem,
+                    loadErrorHandlingPolicy,
                     C.DATA_TYPE_MANIFEST,
                     playbackInfoMediaSource.reflectionEventDispatcher,
                     loadEventInfoF,


### PR DESCRIPTION
## What

Stops the player's ExoPlayer-level retry for **track/video PlaybackInfo (PBI) manifest fetches**, deferring those to tidalapi's new built-in retry (this PR stacks on the TM-1414 tidalapi-retry stack). Player retry is kept for every other call that is not made thrtough tidalapi.

## Why

tidalapi now retries its GET calls internally (three-category `RetryPolicy` + `RetryInterceptor`). Track/video PBI manifest fetches go through tidalapi, but `PlayerLoadErrorHandlingPolicy` also retried the whole PBI load — producing nested/double retry (e.g. a persistent 5xx could trigger ~16 HTTP attempts; timeouts compounded the 8s-base backoff).

## How

- Add `NoRetryLoadErrorHandlingPolicy` — delegates to a default policy but `getRetryDelayMsFor` returns `C.TIME_UNSET`, so `PlaybackInfoLoadableLoaderCallback.onLoadError` treats every load error as fatal (no player retry).
- Select the policy by `ForwardingMediaProduct.productType` at the single choke point `PlaybackInfoMediaSourceFactory.create()`:
    - `TRACK` / `VIDEO` → no-retry policy (tidalapi owns retry)
    - `BROADCAST` / `UC` → unchanged `PlayerLoadErrorHandlingPolicy`
- Move the policy from `PlaybackInfoLoadableLoaderCallbackFactory`'s constructor to its `create()` parameter so it can vary per load.

Video shows the 4 retries as defined in the tidalapi mechanism, to demonstrate this call doesn't use the player's internal retry logic anymore for this one.  
 [Screen Recording 2026-06-16 at 10.05.08.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ca8cf6ef-3102-4272-98d6-7508434a0c33.mov" />](https://app.graphite.com/user-attachments/video/ca8cf6ef-3102-4272-98d6-7508434a0c33.mov)