### PR TITLE
Release tidalapi 0.3.45

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.45] - 2026-06-16
+### Added
+- Automatic retry for network calls using a three-category retry policy (transient, rate-limit, and non-retryable errors). Retries apply to read-only requests (GET/HEAD) and to idempotency-keyed mutations (POST/PATCH/PUT/DELETE carrying an `Idempotency-Key` header); un-keyed mutations are never retried.
+
 ## [0.3.44] - 2026-06-09
 ### Changed
 - Updated generated code using api spec version 1.10.28

--- a/tidalapi/gradle.properties
+++ b/tidalapi/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=SDK module wrapping Tidal Open Api
-version=0.3.44
+version=0.3.45


### PR DESCRIPTION
## What
Release tidalapi `0.3.44` → `0.3.45`.

- **Added:** automatic retry for network calls using a three-category retry policy (transient, rate-limit, non-retryable). Retries cover read-only requests (GET/HEAD) [TM-1414] **and** idempotency-keyed mutations (POST/PATCH/PUT/DELETE carrying an `Idempotency-Key` header) [TM-1415]; un-keyed mutations are never retried.

## Changes
- `tidalapi/gradle.properties` — version bump
- `tidalapi/CHANGELOG.md` — release notes

> Merge and publish this **before** the player release (#332), which consumes the published `tidalapi:0.3.45` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)