### PR TITLE
Release player 0.0.66

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ tidal-sdk-common = { module = "com.tidal.sdk:common", version = "0.2.5" }
 tidal-sdk-auth = { module = "com.tidal.sdk:auth", version = "0.10.1" }
 tidal-sdk-eventproducer = { module = "com.tidal.sdk:eventproducer", version = "0.3.2" }
 tidal-sdk-player = { module = "com.tidal.sdk:player", version = "0.0.39" }
-tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.41" }
+tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.45" }
 
 # Testing
 test-androidx-espresso-core = "androidx.test.espresso:espresso-core:3.5.1"

--- a/player/CHANGELOG.md
+++ b/player/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.66] - 2026-06-16
+### Added
+- `UriSchemeType` argument for the StreamingApi track and video manifest endpoints.
+
+### Changed
+- Updated tidalapi dependency to 0.3.45.
+- Skip player-level retry for TRACK/VIDEO PlaybackInfo fetches to avoid duplicate retries.
+
+### Fixed
+- Fixed `ConcurrentModificationException` when serializing playback session events.
+
 ## [0.0.65] - 2026-06-02
 ### Changed
 - Update tidalapi dependency.

--- a/player/gradle.properties
+++ b/player/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Player module encapsulates the playback functionality of TIDAL media products.
-version=0.0.65
+version=0.0.66


### PR DESCRIPTION
## What
Release player `0.0.65` → `0.0.66`.

- **Added:** `UriSchemeType` argument for the StreamingApi track and video manifest endpoints.
- **Changed:** updated tidalapi dependency to `0.3.45`.
- **Changed:** skip player-level retry for TRACK/VIDEO PlaybackInfo fetches to avoid duplicate retries.
- **Fixed:** `ConcurrentModificationException` when serializing playback session events.

## Changes
- `player/gradle.properties` — version bump
- `gradle/libs.versions.toml` — `tidal-sdk-tidalapi` `0.3.41` → `0.3.45` (consumed by `player/streaming-api`)
- `player/CHANGELOG.md` — release notes

> ⛔️ **Blocked on #331.** player builds against the published `tidalapi:0.3.45` artifact, so this stays in draft until tidalapi 0.3.45 is merged and published — otherwise CI can't resolve the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)