### PR TITLE
TM-1415 Make idempotency-keyed mutations retry-eligible

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -19,8 +19,8 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
 
 /**
  * @param[retryPolicy] The [RetryPolicy] driving automatic retry of failed requests. Defaults to
- *   [DefaultRetryPolicy] (the three-category model, retrying GET/HEAD/OPTIONS only). Pass `null` to
- *   disable retry entirely.
+ *   [DefaultRetryPolicy] (the three-category model, retrying reads and mutations that carry an
+ *   `Idempotency-Key` header). Pass `null` to disable retry entirely.
  * @param[readTimeoutMillis] The OkHttp read timeout, in milliseconds. Must be positive. Defaults to
  *   [DEFAULT_READ_TIMEOUT_MILLIS] (5s). A read that exceeds it surfaces a `SocketTimeoutException`,
  *   which the retry interceptor classifies as a timeout.

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptor.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryInterceptor.kt
@@ -14,7 +14,7 @@ internal class RetryInterceptor(
     @Suppress("ReturnCount")
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        if (!policy.isRetryableRequest(request.method)) {
+        if (!policy.isRetryableRequest(request.method, request.header("Idempotency-Key"))) {
             return chain.proceed(request)
         }
 

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicy.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetryPolicy.kt
@@ -32,6 +32,17 @@ interface RetryPolicy {
      * only; mutations are never retried.
      */
     fun isRetryableRequest(method: String): Boolean = method in setOf("GET", "HEAD", "OPTIONS")
+
+    /**
+     * Whether a request is retry-eligible. Retries the safe read methods GET, HEAD and OPTIONS (per
+     * [isRetryableRequest]), and any mutation carrying an `Idempotency-Key` header (the backend
+     * replays a duplicate keyed mutation, making it safe to retry). Un-keyed mutations are never
+     * retried.
+     *
+     * @param[idempotencyKey] the request's `Idempotency-Key` header value, or `null` when absent.
+     */
+    fun isRetryableRequest(method: String, idempotencyKey: String?): Boolean =
+        isRetryableRequest(method) || idempotencyKey != null
 }
 
 /**


### PR DESCRIPTION
## Why

Step 2 of the `:tidalapi` HTTP retry work (TIDE-1891). Step 1 (TM-1414, on `main`) retries reads only. A mutation carrying an `Idempotency-Key` is backend-sanctioned safe to retry (replay-on-duplicate, 422-on-payload-mismatch), so keyed mutations should be retried under the same model.

Linear: TM-1415  
See [this](https://linear.app/squareup/issue/TIDE-1891/http-retry-mechanism#comment-d9a07fb4) conversation for context.

## What

- Widen `RetryPolicy.isRetryableRequest` with an overload taking the `Idempotency-Key` value; a request is eligible when the header is present.
- `RetryInterceptor.intercept` forwards `request.header("Idempotency-Key")` alongside `request.method`.
- Reuse the existing three-category model and constants unchanged. Un-keyed mutations stay non-retried; GET/HEAD/OPTIONS behavior is unchanged.
- Correct stale "GET/HEAD/OPTIONS only" KDoc on `RetryPolicy` and `RetrofitProvider`.

## Risk Assessment

Low — scoped to `:tidalapi` retry eligibility. Default-on, but only widens which requests are eligible; gated on a backend-sanctioned header. Constants, backoff, and classifier are untouched.