### PR TITLE
TM-1416 Add TidalApiRetryListener seam for tidalapi retry observation

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptor.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptor.kt
@@ -15,6 +15,7 @@ class TidalApiRetryInterceptor(
     private val policy: RetryPolicy,
     private val random: () -> Double = Math::random,
     private val sleep: (Long) -> Unit = Thread::sleep,
+    private val retryListener: TidalApiRetryListener = NoOpTidalApiRetryListener,
 ) : Interceptor {
 
     @Suppress("ReturnCount")
@@ -38,10 +39,15 @@ class TidalApiRetryInterceptor(
                         backOff(chain, attempts, errorCategory)
                         continue
                     }
+                    retryListener.onRetriesExhausted(errorCategory, attempts[errorCategory.ordinal])
                     throw e
                 }
             val nonNullResponse = requireNotNull(response)
-            if (category == null || !hasBudget(attempts, category)) {
+            if (category == null) {
+                return nonNullResponse
+            }
+            if (!hasBudget(attempts, category)) {
+                retryListener.onRetriesExhausted(category, attempts[category.ordinal])
                 return nonNullResponse
             }
             nonNullResponse.close() // Free the body before retrying so it is not leaked.
@@ -55,12 +61,11 @@ class TidalApiRetryInterceptor(
     /** Sleeps [category]'s backoff and records the attempt; throws [IOException] if cancelled. */
     private fun backOff(chain: Interceptor.Chain, attempts: IntArray, category: ErrorCategory) {
         if (chain.call().isCanceled()) throw IOException("Canceled")
+        val attempt = attempts[category.ordinal]
+        val delayMillis = policy.getConfigurationFor(category).computeDelayMillis(attempt, random)
+        retryListener.onRetry(category, attempt, delayMillis)
         try {
-            sleep(
-                policy
-                    .getConfigurationFor(category)
-                    .computeDelayMillis(attempts[category.ordinal], random)
-            )
+            sleep(delayMillis)
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
             throw IOException("Retry backoff interrupted", e)

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryListener.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryListener.kt
@@ -1,0 +1,35 @@
+package com.tidal.sdk.tidalapi.networking
+
+/**
+ * Observation seam for retry decisions made by [TidalApiRetryInterceptor]. Implementations MUST NOT
+ * affect retry behaviour; they are notified only. The default is [NoOpTidalApiRetryListener].
+ */
+interface TidalApiRetryListener {
+
+    /**
+     * Called immediately before each backoff wait.
+     *
+     * @param category the failure category being retried.
+     * @param attempt the 0-based retry index for [category].
+     * @param delayMillis the backoff delay about to be applied.
+     */
+    fun onRetry(category: ErrorCategory, attempt: Int, delayMillis: Long)
+
+    /**
+     * Called when [category]'s retry budget is spent and the failing response/exception is
+     * surfaced.
+     *
+     * @param attempts the total number of retries made for [category].
+     */
+    fun onRetriesExhausted(category: ErrorCategory, attempts: Int)
+}
+
+/**
+ * A [TidalApiRetryListener] that does nothing. The default, so retry overhead/behaviour is
+ * unchanged.
+ */
+object NoOpTidalApiRetryListener : TidalApiRetryListener {
+    override fun onRetry(category: ErrorCategory, attempt: Int, delayMillis: Long) = Unit
+
+    override fun onRetriesExhausted(category: ErrorCategory, attempts: Int) = Unit
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/FakeRetryListener.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/FakeRetryListener.kt
@@ -1,0 +1,26 @@
+package com.tidal.sdk.tidalapi.networking
+
+/** A hand-written [TidalApiRetryListener] that records every callback for assertion in tests. */
+class FakeRetryListener : TidalApiRetryListener {
+
+    data class Retry(val category: ErrorCategory, val attempt: Int, val delayMillis: Long)
+
+    data class Exhausted(val category: ErrorCategory, val attempts: Int)
+
+    private val _retries = mutableListOf<Retry>()
+    private val _exhaustions = mutableListOf<Exhausted>()
+
+    val retries: List<Retry>
+        get() = _retries
+
+    val exhaustions: List<Exhausted>
+        get() = _exhaustions
+
+    override fun onRetry(category: ErrorCategory, attempt: Int, delayMillis: Long) {
+        _retries += Retry(category, attempt, delayMillis)
+    }
+
+    override fun onRetriesExhausted(category: ErrorCategory, attempts: Int) {
+        _exhaustions += Exhausted(category, attempts)
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptorTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptorTest.kt
@@ -21,12 +21,14 @@ class TidalApiRetryInterceptorTest {
     private lateinit var server: MockWebServer
     private val recordedDelays = mutableListOf<Long>()
     private val policy = DefaultRetryPolicy()
+    private var listener = FakeRetryListener()
 
     @BeforeEach
     fun setUp() {
         server = MockWebServer()
         server.start()
         recordedDelays.clear()
+        listener = FakeRetryListener()
     }
 
     @AfterEach
@@ -38,10 +40,11 @@ class TidalApiRetryInterceptorTest {
         retryPolicy: RetryPolicy = policy,
         random: () -> Double = { 1.0 },
         sleep: (Long) -> Unit = recordedDelays::add,
+        retryListener: TidalApiRetryListener = listener,
     ): OkHttpClient =
         OkHttpClient.Builder()
             .readTimeout(200, TimeUnit.MILLISECONDS)
-            .addInterceptor(TidalApiRetryInterceptor(retryPolicy, random, sleep))
+            .addInterceptor(TidalApiRetryInterceptor(retryPolicy, random, sleep, retryListener))
             .build()
 
     private fun get() = Request.Builder().url(server.url("/")).build()
@@ -323,5 +326,113 @@ class TidalApiRetryInterceptorTest {
 
         assertThrows(IOException::class.java) { call.execute() }
         assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `onRetry fires once per retry with ascending attempt and the applied delay`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        client().newCall(get()).execute()
+
+        // base 500ms, cap 16s: 500, 1000, 2000 (× jitter 1.0) — the same values sleep recorded.
+        assertEquals(recordedDelays, listener.retries.map { it.delayMillis })
+        assertEquals(
+            listOf(
+                FakeRetryListener.Retry(ErrorCategory.HTTP_STATUS, 0, 500L),
+                FakeRetryListener.Retry(ErrorCategory.HTTP_STATUS, 1, 1000L),
+                FakeRetryListener.Retry(ErrorCategory.HTTP_STATUS, 2, 2000L),
+            ),
+            listener.retries,
+        )
+    }
+
+    @Test
+    fun `onRetriesExhausted fires once on the response path when the http-status budget is spent`() {
+        repeat(4) { server.enqueue(MockResponse().setResponseCode(500)) }
+
+        client().newCall(get()).execute()
+
+        assertEquals(
+            listOf(FakeRetryListener.Exhausted(ErrorCategory.HTTP_STATUS, 3)),
+            listener.exhaustions,
+        )
+    }
+
+    @Test
+    fun `onRetriesExhausted fires once on the exception path when the network budget is spent`() {
+        repeat(11) {
+            server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+
+        assertEquals(
+            listOf(FakeRetryListener.Exhausted(ErrorCategory.NETWORK, 10)),
+            listener.exhaustions,
+        )
+    }
+
+    @Test
+    fun `onRetriesExhausted fires once on the exception path when the timeout budget is spent`() {
+        repeat(4) { server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)) }
+
+        assertThrows(IOException::class.java) { client().newCall(get()).execute() }
+
+        assertEquals(
+            listOf(FakeRetryListener.Exhausted(ErrorCategory.TIMEOUT, 3)),
+            listener.exhaustions,
+        )
+    }
+
+    @Test
+    fun `a successful response reports nothing`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        assertTrue(listener.retries.isEmpty())
+        assertTrue(listener.exhaustions.isEmpty())
+    }
+
+    @Test
+    fun `a non-429 4xx reports nothing`() {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        client().newCall(get()).execute()
+
+        assertTrue(listener.retries.isEmpty())
+        assertTrue(listener.exhaustions.isEmpty())
+    }
+
+    @Test
+    fun `a non-retried mutation reports nothing`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        client().newCall(post()).execute()
+
+        assertTrue(listener.retries.isEmpty())
+        assertTrue(listener.exhaustions.isEmpty())
+    }
+
+    @Test
+    fun `an interrupted backoff reports nothing`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        val interrupting = client(sleep = { throw InterruptedException("interrupted") })
+
+        assertThrows(IOException::class.java) { interrupting.newCall(get()).execute() }
+        assertTrue(listener.exhaustions.isEmpty())
+        Thread.interrupted()
+    }
+
+    @Test
+    fun `a call cancelled before backoff reports nothing`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200))
+        lateinit var call: Call
+        val cancelling = client(sleep = { call.cancel() })
+        call = cancelling.newCall(get())
+
+        assertThrows(IOException::class.java) { call.execute() }
+        assertTrue(listener.exhaustions.isEmpty())
     }
 }


### PR DESCRIPTION
## Why
The tidalapi retry interceptor makes retry decisions silently. We want to observe those decisions without coupling the retry core to analytics.

Linear: TM-1416

## What
- Add a `TidalApiRetryListener` interface (`onRetry`, `onRetriesExhausted`) plus a default `NoOpTidalApiRetryListener` in `com.tidal.sdk.tidalapi.networking`.
- Report each retry decision and budget exhaustion from `TidalApiRetryInterceptor` through the listener.
- Unit-test the seam with a fake listener (per-retry reports, exhaustion on each category path, and silence for non-retried requests).

## Risk Assessment
Low — the listener defaults to a no-op. No change to retry eligibility, categories, attempt counts, backoff, or jitter; this is a telemetry seam only.

## Stack
1. **#336 (this)** — listener seam
2. #337 — event-producer telemetry + `RetrofitProvider(eventSender)`
3. #338 — player DI wiring (separate; lands after a tidalapi release)