### PR TITLE
TM-1416 Add tidalapi retry telemetry (EventSender-backed)

### DIFF
--- a/tidalapi/build.gradle.kts
+++ b/tidalapi/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     api(libs.kotlinx.serialization.json)
     api(libs.retrofit)
+    api(libs.tidal.sdk.eventproducer)
 
     implementation(libs.kotlinxCoroutinesCore)
     implementation(libs.okhttp.loggingInterceptor)

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/EventProducerRetryListener.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/EventProducerRetryListener.kt
@@ -1,0 +1,55 @@
+package com.tidal.sdk.tidalapi.networking
+
+import com.tidal.sdk.eventproducer.EventSender
+import com.tidal.sdk.eventproducer.model.ConsentCategory
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * A [TidalApiRetryListener] that emits one TIDAL event per retry and per budget-exhaustion through
+ * [EventSender]. Telemetry only — it never affects retry behaviour. Stateless and thread-safe; the
+ * interceptor may invoke it from any HTTP worker thread.
+ */
+internal class EventProducerRetryListener(private val eventSender: EventSender) :
+    TidalApiRetryListener {
+
+    override fun onRetry(category: ErrorCategory, attempt: Int, delayMillis: Long) {
+        val payload =
+            JsonObject(
+                mapOf(
+                    "category" to JsonPrimitive(category.name),
+                    "attempt" to JsonPrimitive(attempt),
+                    "delayMillis" to JsonPrimitive(delayMillis),
+                )
+            )
+        eventSender.sendEvent(
+            EVENT_RETRY,
+            ConsentCategory.NECESSARY,
+            Json.encodeToString(payload),
+            emptyMap(),
+        )
+    }
+
+    override fun onRetriesExhausted(category: ErrorCategory, attempts: Int) {
+        val payload =
+            JsonObject(
+                mapOf(
+                    "category" to JsonPrimitive(category.name),
+                    "attempts" to JsonPrimitive(attempts),
+                )
+            )
+        eventSender.sendEvent(
+            EVENT_RETRIES_EXHAUSTED,
+            ConsentCategory.NECESSARY,
+            Json.encodeToString(payload),
+            emptyMap(),
+        )
+    }
+
+    private companion object {
+        const val EVENT_RETRY = "tidalapi_retry"
+        const val EVENT_RETRIES_EXHAUSTED = "tidalapi_retries_exhausted"
+    }
+}

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.tidalapi.networking
 import com.tidal.sdk.auth.CredentialsProvider
 import com.tidal.sdk.common.d
 import com.tidal.sdk.common.logger
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.tidalapi.generated.models.getOneOfSerializer
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -24,6 +25,9 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
  * @param[readTimeoutMillis] The OkHttp read timeout, in milliseconds. Must be positive. Defaults to
  *   [DEFAULT_READ_TIMEOUT_MILLIS] (5s). A read that exceeds it surfaces a `SocketTimeoutException`,
  *   which the retry interceptor classifies as a timeout.
+ * @param[eventSender] When non-null, retry decisions are reported as TIDAL events through this
+ *   [EventSender]. When null (the default), no retry telemetry is emitted. Does not affect retry
+ *   behaviour.
  */
 class RetrofitProvider
 @JvmOverloads
@@ -32,6 +36,7 @@ constructor(
     private val cacheSize: Long = DEFAULT_CACHE_SIZE,
     private val retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
     private val readTimeoutMillis: Long = DEFAULT_READ_TIMEOUT_MILLIS,
+    eventSender: EventSender? = null,
 ) {
 
     init {
@@ -39,6 +44,9 @@ constructor(
             "readTimeoutMillis must be positive, was $readTimeoutMillis"
         }
     }
+
+    private val retryListener: TidalApiRetryListener =
+        eventSender?.let { EventProducerRetryListener(it) } ?: NoOpTidalApiRetryListener
 
     private val converterFactories: List<Converter.Factory> =
         listOf(
@@ -50,7 +58,11 @@ constructor(
         OkHttpClient.Builder()
             .readTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
             .apply { cacheDir?.let { cache(Cache(it, cacheSize)) } }
-            .apply { retryPolicy?.let { addInterceptor(TidalApiRetryInterceptor(it)) } }
+            .apply {
+                retryPolicy?.let {
+                    addInterceptor(TidalApiRetryInterceptor(it, retryListener = retryListener))
+                }
+            }
             .addInterceptor(AuthInterceptor(credentialsProvider))
             .authenticator(DefaultAuthenticator(credentialsProvider))
             .addInterceptor(getLoggingInterceptor())

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -26,18 +26,30 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
  *   [DEFAULT_READ_TIMEOUT_MILLIS] (5s). A read that exceeds it surfaces a `SocketTimeoutException`,
  *   which the retry interceptor classifies as a timeout.
  * @param[eventSender] When non-null, retry decisions are reported as TIDAL events through this
- *   [EventSender]. When null (the default), no retry telemetry is emitted. Does not affect retry
- *   behaviour.
+ *   [EventSender]. Pass null — or use the constructor without this parameter — to disable retry
+ *   telemetry. Does not affect retry behaviour.
  */
 class RetrofitProvider
-@JvmOverloads
 constructor(
     private val cacheDir: File? = null,
     private val cacheSize: Long = DEFAULT_CACHE_SIZE,
     private val retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
     private val readTimeoutMillis: Long = DEFAULT_READ_TIMEOUT_MILLIS,
-    eventSender: EventSender? = null,
+    eventSender: EventSender?,
 ) {
+
+    /**
+     * Backwards-compatible constructor matching the signature from before retry telemetry was added
+     * (no [EventSender]); telemetry is disabled. Preserves source and binary compatibility for
+     * consumers compiled against earlier tidalapi versions.
+     */
+    @JvmOverloads
+    constructor(
+        cacheDir: File? = null,
+        cacheSize: Long = DEFAULT_CACHE_SIZE,
+        retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
+        readTimeoutMillis: Long = DEFAULT_READ_TIMEOUT_MILLIS,
+    ) : this(cacheDir, cacheSize, retryPolicy, readTimeoutMillis, eventSender = null)
 
     init {
         require(readTimeoutMillis > 0) {

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/EventProducerRetryListenerTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/EventProducerRetryListenerTest.kt
@@ -1,0 +1,46 @@
+package com.tidal.sdk.tidalapi.networking
+
+import com.tidal.sdk.eventproducer.model.ConsentCategory
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EventProducerRetryListenerTest {
+
+    private val eventSender = FakeEventSender()
+    private val listener = EventProducerRetryListener(eventSender)
+
+    @Test
+    fun `onRetry emits a single tidalapi_retry event with the retry payload`() {
+        listener.onRetry(ErrorCategory.HTTP_STATUS, 1, 2000L)
+
+        val event = eventSender.sentEvents.single()
+        assertEquals("tidalapi_retry", event.eventName)
+        assertEquals(ConsentCategory.NECESSARY, event.consentCategory)
+        assertTrue(event.headers.isEmpty())
+
+        val payload = Json.parseToJsonElement(event.payload).jsonObject
+        assertEquals("HTTP_STATUS", payload.getValue("category").jsonPrimitive.content)
+        assertEquals(1, payload.getValue("attempt").jsonPrimitive.int)
+        assertEquals(2000L, payload.getValue("delayMillis").jsonPrimitive.long)
+    }
+
+    @Test
+    fun `onRetriesExhausted emits a single tidalapi_retries_exhausted event with the exhaustion payload`() {
+        listener.onRetriesExhausted(ErrorCategory.NETWORK, 10)
+
+        val event = eventSender.sentEvents.single()
+        assertEquals("tidalapi_retries_exhausted", event.eventName)
+        assertEquals(ConsentCategory.NECESSARY, event.consentCategory)
+        assertTrue(event.headers.isEmpty())
+
+        val payload = Json.parseToJsonElement(event.payload).jsonObject
+        assertEquals("NETWORK", payload.getValue("category").jsonPrimitive.content)
+        assertEquals(10, payload.getValue("attempts").jsonPrimitive.int)
+    }
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/FakeEventSender.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/FakeEventSender.kt
@@ -1,0 +1,31 @@
+package com.tidal.sdk.tidalapi.networking
+
+import com.tidal.sdk.eventproducer.EventSender
+import com.tidal.sdk.eventproducer.model.ConsentCategory
+
+/** A hand-written [EventSender] that records every [sendEvent] call for assertion in tests. */
+class FakeEventSender : EventSender {
+
+    data class SentEvent(
+        val eventName: String,
+        val consentCategory: ConsentCategory,
+        val payload: String,
+        val headers: Map<String, String>,
+    )
+
+    private val _sentEvents = mutableListOf<SentEvent>()
+
+    val sentEvents: List<SentEvent>
+        get() = _sentEvents
+
+    override fun sendEvent(
+        eventName: String,
+        consentCategory: ConsentCategory,
+        payload: String,
+        headers: Map<String, String>,
+    ) {
+        _sentEvents += SentEvent(eventName, consentCategory, payload, headers)
+    }
+
+    override fun setBlockedConsentCategories(blockedConsentCategories: Set<ConsentCategory>) = Unit
+}

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
@@ -1,5 +1,6 @@
 package com.tidal.sdk.tidalapi.networking
 
+import com.tidal.sdk.eventproducer.EventSender
 import java.net.SocketTimeoutException
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -36,10 +37,39 @@ class RetrofitProviderRetryTest {
     private fun api(
         retryPolicy: RetryPolicy? = DefaultRetryPolicy(),
         readTimeoutMillis: Long = RetrofitProvider.DEFAULT_READ_TIMEOUT_MILLIS,
+        eventSender: EventSender? = null,
     ): TestApi =
-        RetrofitProvider(retryPolicy = retryPolicy, readTimeoutMillis = readTimeoutMillis)
+        RetrofitProvider(
+                retryPolicy = retryPolicy,
+                readTimeoutMillis = readTimeoutMillis,
+                eventSender = eventSender,
+            )
             .provideRetrofit(server.url("/").toString(), FakeCredentialsProvider())
             .create(TestApi::class.java)
+
+    @Test
+    fun `emits retry telemetry when an event sender is supplied`() = runTest {
+        // A single 500 then 200 (one retry, ~0.5s wall clock) proves the EventSender-backed
+        // listener is wired through; payload assertions live in EventProducerRetryListenerTest.
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+        val eventSender = FakeEventSender()
+
+        api(eventSender = eventSender).ping()
+
+        assertEquals(listOf("tidalapi_retry"), eventSender.sentEvents.map { it.eventName })
+    }
+
+    @Test
+    fun `emits no telemetry when no event sender is supplied`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+
+        api().ping()
+
+        // No EventSender, so nothing observes the retry — just the normal recovery.
+        assertEquals(2, server.requestCount)
+    }
 
     @Test
     fun `retries a GET by default until success`() = runTest {

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProviderRetryTest.kt
@@ -112,4 +112,21 @@ class RetrofitProviderRetryTest {
             RetrofitProvider(readTimeoutMillis = 0)
         }
     }
+
+    @Test
+    fun `the backwards-compatible constructor without an event sender still retries`() = runTest {
+        // Exercises the pre-telemetry constructor (no EventSender) to guard the binary-compatible
+        // entry point used by consumers built against earlier versions.
+        server.enqueue(MockResponse().setResponseCode(500))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("pong"))
+
+        val response =
+            RetrofitProvider()
+                .provideRetrofit(server.url("/").toString(), FakeCredentialsProvider())
+                .create(TestApi::class.java)
+                .ping()
+
+        assertEquals(200, response.code())
+        assertEquals(2, server.requestCount)
+    }
 }


### PR DESCRIPTION
## Why
Report tidalapi retry decisions to the SDK event producer, without callers having to construct a listener.

Linear: TM-1416

## What
- Add the eventproducer dependency to `:tidalapi` (`api`, since `EventSender` is part of `RetrofitProvider`'s public API).
- Add an internal `EventProducerRetryListener` emitting one event per retry / budget-exhaustion via `EventSender`.
- `RetrofitProvider` accepts `eventSender: EventSender?` (builds the listener when present), with a secondary constructor preserving the pre-telemetry signature for binary compatibility with older consumers/player builds.
- Tests for the listener and the provider wiring.

No version bump and no player wiring in this PR — those follow separately (the tidalapi 0.3.47 release, then the player EventSender wiring once 0.3.47 is published).

## Risk Assessment
Low — telemetry is opt-in via `eventSender`; default behaviour unchanged. Binary-compatible for existing consumers.