### PR TITLE
TM-1416 Wire player EventSender into tidalapi retry telemetry

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ tidal-sdk-common = { module = "com.tidal.sdk:common", version = "0.2.5" }
 tidal-sdk-auth = { module = "com.tidal.sdk:auth", version = "0.10.1" }
 tidal-sdk-eventproducer = { module = "com.tidal.sdk:eventproducer", version = "0.3.2" }
 tidal-sdk-player = { module = "com.tidal.sdk:player", version = "0.0.39" }
-tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.45" }
+tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.47" }
 
 # Testing
 test-androidx-espresso-core = "androidx.test.espresso:espresso-core:3.5.1"

--- a/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
+++ b/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.streamingapi.playlogtest
 import android.util.Base64
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
@@ -38,6 +39,7 @@ class PlayLogTestStreamingApiComponentFactory(private val trackPlaybackInfo: Pla
         tidalApiCacheDir: File?,
         apiEndpoint: String,
         openApiEndpoint: String,
+        eventSender: EventSender?,
     ): StreamingApiComponent {
         return object : StreamingApiComponent {
             override val streamingApi: StreamingApi = PlayLogTestStreamingApi(trackPlaybackInfo)

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.di
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.offlineplay.OfflinePlayProvider
 import com.tidal.sdk.player.streamingapi.StreamingApiModuleRoot
@@ -39,6 +40,7 @@ internal object StreamingApiModule {
         @Named("tidalApiCacheDir") tidalApiCacheDir: File,
         @Named("apiEndpoint") apiEndpoint: String,
         @Named("openApiEndpoint") openApiEndpoint: String,
+        eventSender: EventSender,
     ) =
         StreamingApiModuleRoot(
                 okHttpClient,
@@ -50,6 +52,7 @@ internal object StreamingApiModule {
                 tidalApiCacheDir,
                 apiEndpoint,
                 openApiEndpoint,
+                eventSender,
             )
             .streamingApi
 }

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.streamingapi
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.di.DaggerStreamingApiComponent
 import com.tidal.sdk.player.streamingapi.playbackinfo.offline.OfflinePlaybackInfoProvider
@@ -18,6 +19,7 @@ class StreamingApiModuleRoot(
     tidalApiCacheDir: File?,
     apiEndpoint: String,
     openApiEndpoint: String,
+    eventSender: EventSender?,
 ) {
 
     val streamingApi =
@@ -32,6 +34,7 @@ class StreamingApiModuleRoot(
                 tidalApiCacheDir,
                 apiEndpoint,
                 openApiEndpoint,
+                eventSender,
             )
             .streamingApi
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.streamingapi.di
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.StreamingApiTimeoutConfig
@@ -41,6 +42,7 @@ interface StreamingApiComponent {
             @BindsInstance @Named("tidalApiCacheDir") tidalApiCacheDir: File?,
             @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
             @BindsInstance @Named("openApiEndpoint") openApiEndpoint: String,
+            @BindsInstance eventSender: EventSender?,
         ): StreamingApiComponent
     }
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiModule.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiModule.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.streamingapi.di
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.StreamingApiDefault
@@ -54,11 +55,12 @@ internal object StreamingApiModule {
         credentialsProvider: CredentialsProvider,
         @Named("tidalApiCacheDir") cacheDir: File?,
         @Named("openApiEndpoint") openApiEndpoint: String,
+        eventSender: EventSender?,
     ): TidalApiClient =
         TidalApiClient(
             credentialsProvider,
             baseUrl = openApiEndpoint,
-            retrofitProvider = RetrofitProvider(cacheDir),
+            retrofitProvider = RetrofitProvider(cacheDir, eventSender = eventSender),
         )
 
     @Provides

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
@@ -62,6 +62,7 @@ internal class StreamingApiDefaultTest {
                     tidalApiCacheDir = null,
                     apiEndpoint = Common.TIDAL_API_ENDPOINT_V1,
                     openApiEndpoint = Common.TIDAL_OPEN_API_ENDPOINT_V2,
+                    eventSender = null,
                 )
                 .streamingApi
     }


### PR DESCRIPTION
## Why

Make player-issued tidalapi requests emit retry telemetry by threading the player's existing `EventSender` through streaming-api's DI into `RetrofitProvider`.

## What

- Consume tidalapi `0.3.47` (`gradle/libs.versions.toml`). Checks will pass once that exists.



- streaming-api: `@BindsInstance eventSender: EventSender?` on `StreamingApiComponent.Factory`, `eventSender` ctor param on `StreamingApiModuleRoot`, and `provideTidalApiClient` passes it to `RetrofitProvider(cacheDir, eventSender = …)`.
- player `di/StreamingApiModule.streamingApi`: inject `EventSender`, pass through.
- Update `PlayLogTestStreamingApiComponentFactory` and `StreamingApiDefaultTest` for the new param.

## ⚠️ Blocked / sequencing

Top of the stack: #336 → #337 → #342 → #338. Consumes tidalapi 0.3.47, which is only published once #342 merges and the release runs — so CI cannot pass here until then.

## Risk Assessment

Low — telemetry only; passing `null` leaves retries unobserved. No change to playback or retry behaviour.