### PR TITLE
Expose retry interceptor publicly as TidalApiRetryInterceptor

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Exposed the retry interceptor publicly as `TidalApiRetryInterceptor`, so consumers can reuse the same retry logic (driven by a `RetryPolicy`) in their own Retrofit/OkHttp instances.
 
 ## [0.3.45] - 2026-06-16
 ### Added

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -50,7 +50,7 @@ constructor(
         OkHttpClient.Builder()
             .readTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
             .apply { cacheDir?.let { cache(Cache(it, cacheSize)) } }
-            .apply { retryPolicy?.let { addInterceptor(RetryInterceptor(it)) } }
+            .apply { retryPolicy?.let { addInterceptor(TidalApiRetryInterceptor(it)) } }
             .addInterceptor(AuthInterceptor(credentialsProvider))
             .authenticator(DefaultAuthenticator(credentialsProvider))
             .addInterceptor(getLoggingInterceptor())

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptor.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptor.kt
@@ -4,8 +4,14 @@ import java.io.IOException
 import okhttp3.Interceptor
 import okhttp3.Response
 
-/** Retries eligible requests per the [RetryPolicy], backing off per [ErrorCategory]. */
-internal class RetryInterceptor(
+/**
+ * Retries eligible requests per the [RetryPolicy], backing off per [ErrorCategory].
+ *
+ * Public so consumers of the TIDAL API can reuse the same retry logic in their own Retrofit/OkHttp
+ * instances, e.g.
+ * `OkHttpClient.Builder().addInterceptor(TidalApiRetryInterceptor(DefaultRetryPolicy()))`.
+ */
+class TidalApiRetryInterceptor(
     private val policy: RetryPolicy,
     private val random: () -> Double = Math::random,
     private val sleep: (Long) -> Unit = Thread::sleep,

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptorTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/TidalApiRetryInterceptorTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class RetryInterceptorTest {
+class TidalApiRetryInterceptorTest {
 
     private lateinit var server: MockWebServer
     private val recordedDelays = mutableListOf<Long>()
@@ -41,7 +41,7 @@ class RetryInterceptorTest {
     ): OkHttpClient =
         OkHttpClient.Builder()
             .readTimeout(200, TimeUnit.MILLISECONDS)
-            .addInterceptor(RetryInterceptor(retryPolicy, random, sleep))
+            .addInterceptor(TidalApiRetryInterceptor(retryPolicy, random, sleep))
             .build()
 
     private fun get() = Request.Builder().url(server.url("/")).build()


### PR DESCRIPTION
## What

Exposes the tidalapi retry interceptor publicly so consumers of the TIDAL API module can reuse the same retry logic in their own Retrofit/OkHttp instances.

- Renames the previously `internal` `RetryInterceptor` to `TidalApiRetryInterceptor` and makes it `public`.
- Updates `RetrofitProvider` and the test to the new name; renames the source and test files to match.
- Adds a CHANGELOG entry under `[Unreleased]`.

## Why

The retry policy types (`RetryPolicy`, `DefaultRetryPolicy`, `BackoffConfiguration`, `ErrorCategory`) were already public, but the interceptor wiring them together was `internal` — so consumers could describe a policy but not actually apply it outside `RetrofitProvider`. Exposing the interceptor lets them attach identical retry behaviour to any OkHttp client.

## Usage

```kotlin
OkHttpClient.Builder()
    .addInterceptor(TidalApiRetryInterceptor(DefaultRetryPolicy())) // or a custom RetryPolicy
    .build()
```

## Notes

- Error classification (which HTTP codes / exceptions map to which `ErrorCategory`) remains `internal` and fixed — consumers control backoff timing, retry counts, and request eligibility via `RetryPolicy`, which is the intended tuning surface.
- No public API change beyond the interceptor itself; `api-surface.snapshot` tracks the OpenAPI spec, not Kotlin visibility, so it is unaffected.

## Testing

- `:tidalapi:compileDebugKotlin` / `:tidalapi:compileDebugUnitTestKotlin` pass.
- `TidalApiRetryInterceptorTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
