### PR TITLE
ci(fossa): scope FOSSA to shipped deps instead of diff-mode

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,6 +1,32 @@
 version: 3
 
+# FOSSA should only see the dependencies the SDK actually ships. By default the
+# Gradle analyzer unions every resolvable configuration across every target,
+# which pulls in build-time tooling (Android Unified Test Platform, dokka, KSP,
+# annotation processors, vanniktech PGP signing). Those carry a large backlog of
+# vulnerabilities that never reach SDK consumers, so they must not gate PRs.
 targets:
   only:
     - type: gradle
       path: .
+  exclude:
+    # Stray Python target picked up under tidalapi/bin.
+    - type: setuptools
+    # Demo apps are not published.
+    - { type: gradle, path: ., target: ':auth:apps:demo' }
+    - { type: gradle, path: ., target: ':eventproducer:apps:demo' }
+    - { type: gradle, path: ., target: ':player:apps:demo' }
+    - { type: gradle, path: ., target: ':tidalapi:apps:demo' }
+    # Test helper module, not part of the shipped runtime surface.
+    - { type: gradle, path: ., target: ':player:testutil' }
+
+# Restrict resolution to the published runtime classpaths only. This drops the
+# build-tooling configurations (kapt/ksp/dokka/UTP) that fossa-cli does not
+# exclude on its own. `releaseRuntimeClasspath` covers the Android library
+# modules; `runtimeClasspath` covers the JVM modules (bom, jvm libraries).
+# Note: `configurations-only` is an experimental fossa-cli feature.
+experimental:
+  gradle:
+    configurations-only:
+      - releaseRuntimeClasspath
+      - runtimeClasspath

--- a/.github/workflows/fossa-scan.yml
+++ b/.github/workflows/fossa-scan.yml
@@ -3,11 +3,6 @@ name: FOSSA Scans
 on:
   workflow_call:
     inputs:
-      base-sha:
-        description: "Base revision for `fossa test --diff`. When empty, the diff test is skipped."
-        required: false
-        type: string
-        default: ""
       branch:
         description: "FOSSA branch label for the analyze step. When empty, fossa-cli detects it."
         required: false
@@ -45,12 +40,13 @@ jobs:
           branch: ${{ inputs.branch }}
 
       - name: "Run FOSSA Tests"
-        # Skipped on analyze-only baseline runs (no base revision supplied).
-        if: ${{ inputs.run-fossa-tests && inputs.base-sha != '' }}
+        # Skipped on analyze-only baseline runs (push:main).
+        if: ${{ inputs.run-fossa-tests }}
         uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7
         with:
           api-key: ${{secrets.fossaApiKey}}
+          # Full test against the shipped-dependency surface (see .fossa.yml,
+          # which filters out build-time tooling). No diff mode: the scan is
+          # scoped tightly enough that the whole result can gate PRs, which also
+          # makes it robust to stacked PRs and newly-published tooling CVEs.
           run-tests: true
-          # Diff mode: fail only on issues introduced vs the base revision, so
-          # the pre-existing backlog stops blocking unrelated PRs.
-          test-diff-revision: ${{ inputs.base-sha }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,7 +10,9 @@ jobs:
 
   fossa-baseline:
     name: FOSSA baseline scan (main)
-    # Analyze-only scan of `main` so PRs have a labelled baseline to diff against.
+    # Analyze-only scan that keeps the `main` branch populated in the FOSSA
+    # dashboard. PRs run their own full `fossa test`, so this is not used for
+    # gating.
     uses: ./.github/workflows/fossa-scan.yml
     with:
       branch: main

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,9 +31,6 @@ jobs:
   trigger-fossa-scan:
     name: Trigger FOSSA Scan
     uses: ./.github/workflows/fossa-scan.yml
-    with:
-      # Base revision for `fossa test --diff` (key differs per event).
-      base-sha: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
     secrets:
       pat: ${{ secrets.PACKAGES_PAT }}
       fossaApiKey: ${{ secrets.FOSSA_API_KEY_FULL }}


### PR DESCRIPTION
FOSSA, the gift that keeps on giving. Here is a new attempt at getting it to be silent. 😁 

## Problem

FOSSA scans were failing on effectively every PR. The diff-mode gate added in TM-1359 (#312) fails three different ways, all observed on live PRs:

1. **Stacked PRs** — `fossa test --diff` uses `pull_request.base.sha`, which for a stacked PR is a sibling branch head FOSSA never analyzed → `Revision not found` (PRs #337, #338).
2. **Phantom "new" issues** — diffing against a valid baseline still reported "6 new issues", all `io.netty` build-tooling CVEs (CVE-2026-50020 / -50560 / -50010) published *after* the baseline scan. The Netty versions were identical and untouched by the PR (PR #336).
3. **Legacy base commits** — PRs based on un-analyzed `main` commits failed the same `Revision not found` way (PR #329).

## Root cause

`fossa-cli`'s Gradle analyzer unions **every resolvable configuration** across **every target**, then uploads the lot as "production". The ~50-issue backlog is entirely build-time tooling that never ships to SDK consumers:

- `com.android.tools.utp:*` + `com.google.testing.platform:*` (Android Unified Test Platform) → grpc-netty, protobuf, netty-*
- `org.jetbrains.dokka:*` (docs)
- `org.bouncycastle:bcpg/bcpkix` (vanniktech publish PGP signing)
- KSP / dagger-compiler / moshi-codegen (annotation processors)
- the `apps:demo` apps, `player:testutil`, and a stray `setuptools@tidalapi/bin/` Python target

`fossa-cli`'s built-in test/dev exclusion list covers `testImplementation`/`androidTest*` but **not** `kapt`/`ksp`/`dokka`/UTP, so they leak in as production deps.

## Fix

Scope FOSSA to the **shipped runtime surface** in `.fossa.yml`:

- `experimental.gradle.configurations-only: [releaseRuntimeClasspath, runtimeClasspath]` — Android libs + JVM modules, dropping all build-tooling configurations.
- `targets.exclude` — the demo apps, the test-helper module, and the stray Python target.

With the noise gone, the PR check reverts to a full `fossa test` (no diff). It gates only genuine shipped-dependency issues and is **immune to stacked PRs and newly-published tooling CVEs** — the two failure modes that broke diff-mode. The `push:main` baseline analyze is kept solely to populate the dashboard's `main` branch (no longer load-bearing for gating).

## Verification

`fossa analyze --output` locally with the new config:

- **468 → 95** dependencies analyzed.
- **Zero** build-tooling vulnerabilities remaining (netty, UTP, protobuf, grpc, bouncycastle, dokka, KSP, dagger-compiler all gone).
- Shipped runtime deps retained at their resolved versions (media3, okhttp 4.12, retrofit, moshi, gson, dagger runtime, coroutines 1.10.2, serialization, tink, guava, rxjava, the `com.tidal.sdk:*` modules). Spot-checked that no real runtime dep was dropped.

### Caveat

`fossa test` against the reduced set can't be run locally (needs the API key + an uploaded revision). If any *shipped* dep carries a live CVE, the check will fail **legitimately** — that's the intended gating, and would need a real fix/triage rather than config. The first post-merge baseline + PR run will confirm.

Refs TM-1359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)