### PR TITLE
Release tidalapi 0.3.46

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.46] - 2026-06-18
 ### Added
 - Exposed the retry interceptor publicly as `TidalApiRetryInterceptor`, so consumers can reuse the same retry logic (driven by a `RetryPolicy`) in their own Retrofit/OkHttp instances.
 

--- a/tidalapi/gradle.properties
+++ b/tidalapi/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=SDK module wrapping Tidal Open Api
-version=0.3.45
+version=0.3.46


### PR DESCRIPTION
## What

Releases tidalapi **0.3.46**.

- Bumps `version` in `tidalapi/gradle.properties` from `0.3.45` to `0.3.46`.
- Promotes the `[Unreleased]` CHANGELOG entry to a dated `0.3.46` section.

## Included change

- Exposed the retry interceptor publicly as `TidalApiRetryInterceptor` (#339), so consumers can reuse the same retry logic (driven by a `RetryPolicy`) in their own Retrofit/OkHttp instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
