### PR TITLE
TM-1416 Release tidalapi 0.3.47 (retry telemetry)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,7 @@ tidal-sdk-common = { module = "com.tidal.sdk:common", version = "0.2.5" }
 tidal-sdk-auth = { module = "com.tidal.sdk:auth", version = "0.10.1" }
 tidal-sdk-eventproducer = { module = "com.tidal.sdk:eventproducer", version = "0.3.2" }
 tidal-sdk-player = { module = "com.tidal.sdk:player", version = "0.0.39" }
-tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.45" }
+tidal-sdk-tidalapi = { module = "com.tidal.sdk:tidalapi", version = "0.3.47" }
 
 # Testing
 test-androidx-espresso-core = "androidx.test.espresso:espresso-core:3.5.1"

--- a/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
+++ b/player/src/androidTest/kotlin/com/tidal/sdk/player/streamingapi/playlogtest/PlayLogTestStreamingApiComponentFactory.kt
@@ -3,6 +3,7 @@ package com.tidal.sdk.player.streamingapi.playlogtest
 import android.util.Base64
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.common.model.AssetPresentation
 import com.tidal.sdk.player.common.model.AudioMode
@@ -38,6 +39,7 @@ class PlayLogTestStreamingApiComponentFactory(private val trackPlaybackInfo: Pla
         tidalApiCacheDir: File?,
         apiEndpoint: String,
         openApiEndpoint: String,
+        eventSender: EventSender?,
     ): StreamingApiComponent {
         return object : StreamingApiComponent {
             override val streamingApi: StreamingApi = PlayLogTestStreamingApi(trackPlaybackInfo)

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/StreamingApiModule.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.di
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.offlineplay.OfflinePlayProvider
 import com.tidal.sdk.player.streamingapi.StreamingApiModuleRoot
@@ -39,6 +40,7 @@ internal object StreamingApiModule {
         @Named("tidalApiCacheDir") tidalApiCacheDir: File,
         @Named("apiEndpoint") apiEndpoint: String,
         @Named("openApiEndpoint") openApiEndpoint: String,
+        eventSender: EventSender,
     ) =
         StreamingApiModuleRoot(
                 okHttpClient,
@@ -50,6 +52,7 @@ internal object StreamingApiModule {
                 tidalApiCacheDir,
                 apiEndpoint,
                 openApiEndpoint,
+                eventSender,
             )
             .streamingApi
 }

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiModuleRoot.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.streamingapi
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.di.DaggerStreamingApiComponent
 import com.tidal.sdk.player.streamingapi.playbackinfo.offline.OfflinePlaybackInfoProvider
@@ -18,6 +19,7 @@ class StreamingApiModuleRoot(
     tidalApiCacheDir: File?,
     apiEndpoint: String,
     openApiEndpoint: String,
+    eventSender: EventSender?,
 ) {
 
     val streamingApi =
@@ -32,6 +34,7 @@ class StreamingApiModuleRoot(
                 tidalApiCacheDir,
                 apiEndpoint,
                 openApiEndpoint,
+                eventSender,
             )
             .streamingApi
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiComponent.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.streamingapi.di
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.StreamingApiTimeoutConfig
@@ -41,6 +42,7 @@ interface StreamingApiComponent {
             @BindsInstance @Named("tidalApiCacheDir") tidalApiCacheDir: File?,
             @BindsInstance @Named("apiEndpoint") apiEndpoint: String,
             @BindsInstance @Named("openApiEndpoint") openApiEndpoint: String,
+            @BindsInstance eventSender: EventSender?,
         ): StreamingApiComponent
     }
 

--- a/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiModule.kt
+++ b/player/streaming-api/src/main/kotlin/com/tidal/sdk/player/streamingapi/di/StreamingApiModule.kt
@@ -2,6 +2,7 @@ package com.tidal.sdk.player.streamingapi.di
 
 import com.google.gson.Gson
 import com.tidal.sdk.auth.CredentialsProvider
+import com.tidal.sdk.eventproducer.EventSender
 import com.tidal.sdk.player.common.model.ApiError
 import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.StreamingApiDefault
@@ -54,11 +55,12 @@ internal object StreamingApiModule {
         credentialsProvider: CredentialsProvider,
         @Named("tidalApiCacheDir") cacheDir: File?,
         @Named("openApiEndpoint") openApiEndpoint: String,
+        eventSender: EventSender?,
     ): TidalApiClient =
         TidalApiClient(
             credentialsProvider,
             baseUrl = openApiEndpoint,
-            retrofitProvider = RetrofitProvider(cacheDir),
+            retrofitProvider = RetrofitProvider(cacheDir, eventSender = eventSender),
         )
 
     @Provides

--- a/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
+++ b/player/streaming-api/src/test/kotlin/com/tidal/sdk/player/streamingapi/StreamingApiDefaultTest.kt
@@ -62,6 +62,7 @@ internal class StreamingApiDefaultTest {
                     tidalApiCacheDir = null,
                     apiEndpoint = Common.TIDAL_API_ENDPOINT_V1,
                     openApiEndpoint = Common.TIDAL_OPEN_API_ENDPOINT_V2,
+                    eventSender = null,
                 )
                 .streamingApi
     }

--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.47] - 2026-06-19
+### Added
+- Retry telemetry: `RetrofitProvider` accepts an optional `EventSender` that, when provided, reports each retry and budget-exhaustion as a TIDAL event. Observation is added through a `TidalApiRetryListener` seam (default no-op), so default retry behaviour and overhead are unchanged.
+
 ## [0.3.46] - 2026-06-18
 ### Added
 - Exposed the retry interceptor publicly as `TidalApiRetryInterceptor`, so consumers can reuse the same retry logic (driven by a `RetryPolicy`) in their own Retrofit/OkHttp instances.

--- a/tidalapi/gradle.properties
+++ b/tidalapi/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=SDK module wrapping Tidal Open Api
-version=0.3.46
+version=0.3.47


### PR DESCRIPTION
## Why
Cut a tidalapi release containing the retry-telemetry API (#337), so the player can consume it (#338). This is the version bump that publishes `0.3.47` to Maven on merge.

Linear: TM-1416

## What
- Bump `tidalapi/gradle.properties`: `0.3.46` → `0.3.47`.
- Add the `## [0.3.47]` `tidalapi/CHANGELOG.md` entry for the retry telemetry (required by the changelog check).

## Sequencing
Stacked on #336/#337. On merge, post-merge publishes tidalapi 0.3.47; that unblocks #338 (which consumes 0.3.47). Adjust the number if the release process assigns something other than 0.3.47.

## Risk Assessment
Low — version + changelog only; no code change.