### PR TITLE
Add stack traces to playback info fetch errors

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
@@ -25,6 +25,9 @@ import java.io.IOException
 import okhttp3.ResponseBody
 import retrofit2.Response
 
+private const val MAX_PLAYBACK_INFO_FETCH_ERROR_MESSAGE_LENGTH = 4_000
+private const val PLAYBACK_INFO_FETCH_STACK_TRACE_TRUNCATED = "\n… stack trace truncated …\n"
+
 /**
  * Communicates with the streaming api, but with additional operations that do not belong in the
  * streaming api itself, such as event tracking and convenience methods only used in the playback
@@ -147,7 +150,7 @@ internal class StreamingApiRepository(
             return ret
         } catch (throwable: Throwable) {
             endReason = EndReason.ERROR
-            errorMessage = throwable.message
+            errorMessage = throwable.stackTraceForPlaybackInfoFetchEvent()
             errorCode =
                 errorHandler.getErrorCode(throwable, ErrorCodeFactory.Extra.PlaybackInfoFetch)
             throw IOException(throwable)
@@ -193,4 +196,20 @@ internal class StreamingApiRepository(
                     "ProductType ${forwardingMediaProduct.productType} can't be offlined."
                 )
         }
+
+    private fun Throwable.stackTraceForPlaybackInfoFetchEvent(): String {
+        val stackTrace = stackTraceToString()
+        return if (stackTrace.length <= MAX_PLAYBACK_INFO_FETCH_ERROR_MESSAGE_LENGTH) {
+            stackTrace
+        } else {
+            val availableLength =
+                MAX_PLAYBACK_INFO_FETCH_ERROR_MESSAGE_LENGTH -
+                    PLAYBACK_INFO_FETCH_STACK_TRACE_TRUNCATED.length
+            val startLength = availableLength * 3 / 4
+            val endLength = availableLength - startLength
+            stackTrace.take(startLength) +
+                PLAYBACK_INFO_FETCH_STACK_TRACE_TRUNCATED +
+                stackTrace.takeLast(endLength)
+        }
+    }
 }

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
@@ -255,7 +255,7 @@ internal class StreamingApiRepositoryTest {
         runBlocking {
             val startTimestamp = -9L
             val endTimestamp = -4L
-            val errorMessage = "errorMessage"
+            val throwableMessage = "errorMessage"
             val errorCode = "errorCode"
             whenever(trueTimeWrapper.currentTimeMillis).thenReturn(startTimestamp, endTimestamp)
             val streamingSessionId = "streamingSessionId"
@@ -267,8 +267,8 @@ internal class StreamingApiRepositoryTest {
                 }
             val productQuality: ProductQuality
             val playbackMode = PlaybackMode.STREAM
-            val runtimeException =
-                mock<RuntimeException> { on { it.message } doReturn errorMessage }
+            val runtimeException = RuntimeException(throwableMessage)
+            val errorMessage = runtimeException.stackTraceToString()
             whenever(
                     errorHandler.getErrorCode(
                         runtimeException,


### PR DESCRIPTION
## Summary
- Report a bounded stack trace in playback_info_fetch errorMessage instead of only Throwable.message
- Preserve both the beginning and end of long stack traces with a truncation marker
- Update playback info fetch failure test expectations

## Verification
- Commit hook ran ktfmt and detekt successfully
- Attempted: ./gradlew :player:playback-engine:testDebugUnitTest --tests com.tidal.sdk.player.playbackengine.StreamingApiRepositoryTest
  - Blocked locally: Android SDK location is not configured (ANDROID_HOME/sdk.dir missing)
