### PR TITLE
Fix selective testing for nested Gradle modules

### DIFF
--- a/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/AffectedTestDetectionPlugin.kt
+++ b/buildlogic/src/main/kotlin/com/tidal/sdk/plugins/AffectedTestDetectionPlugin.kt
@@ -129,11 +129,16 @@ private class AffectedModuleDetector(private val project: Project) {
     }
 
     private fun findProjectForFile(file: String): Project? {
-        return allProjects.firstOrNull { project ->
-            if (project == rootProject) return@firstOrNull false
-            val projectPath = project.projectDir.relativeTo(rootDir).path
-            file.startsWith("$projectPath/")
-        }
+        // Pick the most specific (longest path) matching project. A simple "first match" would
+        // attribute a file under a nested module (e.g. player/playback-engine/...) to its parent
+        // project (:player), because the parent's path is also a prefix of the file path.
+        return allProjects
+            .filter { it != rootProject }
+            .filter { project ->
+                val projectPath = project.projectDir.relativeTo(rootDir).path
+                file.startsWith("$projectPath/")
+            }
+            .maxByOrNull { it.projectDir.relativeTo(rootDir).path.length }
     }
 
     private fun findAllAffectedProjects(directlyAffectedProjects: Set<Project>): Set<Project> {


### PR DESCRIPTION
## Problem

Selective unit testing (`detectAffectedModules`) skipped tests for nested modules. Concretely, PR #345 changed only files under `player/playback-engine/`, yet CI ran `:player:test` and `:player:apps:demo:test` — never `:player:playback-engine:test`. The modified test passed unrun and only failed later on PR #347's full build.

Root cause is in `AffectedTestDetectionPlugin.findProjectForFile`. It mapped a changed file to a module using `firstOrNull` on a path-prefix match. Because `:player` (dir `player`) is also a prefix of `player/playback-engine/...`, and `allProjects` is iterated parent-before-child, the file was attributed to the parent `:player`. The child's own test task was never generated.

This affected **every** change to a nested module whose parent is itself a Gradle project: the child's tests, plus anything depending on the child, were silently skipped.

## Solution

Match the most specific module — the one with the longest matching path — instead of the first. `maxByOrNull` on path length picks `:player:playback-engine` over `:player`, independent of iteration order.

This change touches `buildlogic/`, so CI runs the full test suite here.