### PR TITLE
TM-1550 Rethrow CancellationException in StreamingApiRepository

### DIFF
--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
@@ -22,6 +22,7 @@ import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import okhttp3.ResponseBody
 import retrofit2.Response
 
@@ -73,28 +74,34 @@ internal class StreamingApiRepository(
         val startTimestamp = trueTimeWrapper.currentTimeMillis
         var errorMessage: String? = null
         var errorCode: String? = null
-        lateinit var endReason: EndReason
+        var endReason: EndReason? = null
         try {
             val ret = streamingApi.getDrmLicense(licenseUrl, payload)
             endReason = EndReason.COMPLETE
             return ret
+        } catch (e: CancellationException) {
+            throw e
         } catch (throwable: Throwable) {
             endReason = EndReason.ERROR
             errorMessage = throwable.message
             errorCode = errorHandler.getErrorCode(throwable, ErrorCodeFactory.Extra.DrmLicenseFetch)
             throw mediaDrmCallbackExceptionFactory.create(throwable)
         } finally {
-            eventReporter.report(
-                DrmLicenseFetch.Payload(
-                    streamingSessionId,
-                    startTimestamp,
-                    trueTimeWrapper.currentTimeMillis,
-                    endReason,
-                    errorMessage,
-                    errorCode,
-                ),
-                extras,
-            )
+            // endReason is only set when the request completed or failed; on cancellation it stays
+            // null and we skip reporting entirely.
+            endReason?.let {
+                eventReporter.report(
+                    DrmLicenseFetch.Payload(
+                        streamingSessionId,
+                        startTimestamp,
+                        trueTimeWrapper.currentTimeMillis,
+                        it,
+                        errorMessage,
+                        errorCode,
+                    ),
+                    extras,
+                )
+            }
         }
     }
 
@@ -109,7 +116,7 @@ internal class StreamingApiRepository(
         val startTimestamp = trueTimeWrapper.currentTimeMillis
         var errorMessage: String? = null
         var errorCode: String? = null
-        lateinit var endReason: EndReason
+        var endReason: EndReason? = null
         try {
             val ret =
                 when (forwardingMediaProduct.productType) {
@@ -148,6 +155,8 @@ internal class StreamingApiRepository(
                 }
             endReason = EndReason.COMPLETE
             return ret
+        } catch (e: CancellationException) {
+            throw e
         } catch (throwable: Throwable) {
             endReason = EndReason.ERROR
             errorMessage = throwable.stackTraceForPlaybackInfoFetchEvent()
@@ -155,17 +164,21 @@ internal class StreamingApiRepository(
                 errorHandler.getErrorCode(throwable, ErrorCodeFactory.Extra.PlaybackInfoFetch)
             throw IOException(throwable)
         } finally {
-            eventReporter.report(
-                PlaybackInfoFetch.Payload(
-                    streamingSessionId,
-                    startTimestamp,
-                    trueTimeWrapper.currentTimeMillis,
-                    endReason,
-                    errorMessage,
-                    errorCode,
-                ),
-                forwardingMediaProduct.extras,
-            )
+            // endReason is only set when the request completed or failed; on cancellation it stays
+            // null and we skip reporting entirely.
+            endReason?.let {
+                eventReporter.report(
+                    PlaybackInfoFetch.Payload(
+                        streamingSessionId,
+                        startTimestamp,
+                        trueTimeWrapper.currentTimeMillis,
+                        it,
+                        errorMessage,
+                        errorCode,
+                    ),
+                    forwardingMediaProduct.extras,
+                )
+            }
         }
     }
 

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepository.kt
@@ -74,34 +74,38 @@ internal class StreamingApiRepository(
         val startTimestamp = trueTimeWrapper.currentTimeMillis
         var errorMessage: String? = null
         var errorCode: String? = null
-        var endReason: EndReason? = null
+        lateinit var endReason: EndReason
         try {
             val ret = streamingApi.getDrmLicense(licenseUrl, payload)
             endReason = EndReason.COMPLETE
             return ret
-        } catch (e: CancellationException) {
-            throw e
+        } catch (cancellation: CancellationException) {
+            // Cancellation (e.g. user skip, or a request abandoned under slow network) is not a
+            // failure. We still report it with EndReason.OTHER to keep visibility into how long the
+            // request ran before being cancelled, then rethrow as-is to preserve coroutine
+            // cancellation semantics.
+            endReason = EndReason.OTHER
+            errorMessage = cancellation.cancellationEventMessage()
+            errorCode =
+                errorHandler.getErrorCode(cancellation, ErrorCodeFactory.Extra.DrmLicenseFetch)
+            throw cancellation
         } catch (throwable: Throwable) {
             endReason = EndReason.ERROR
             errorMessage = throwable.message
             errorCode = errorHandler.getErrorCode(throwable, ErrorCodeFactory.Extra.DrmLicenseFetch)
             throw mediaDrmCallbackExceptionFactory.create(throwable)
         } finally {
-            // endReason is only set when the request completed or failed; on cancellation it stays
-            // null and we skip reporting entirely.
-            endReason?.let {
-                eventReporter.report(
-                    DrmLicenseFetch.Payload(
-                        streamingSessionId,
-                        startTimestamp,
-                        trueTimeWrapper.currentTimeMillis,
-                        it,
-                        errorMessage,
-                        errorCode,
-                    ),
-                    extras,
-                )
-            }
+            eventReporter.report(
+                DrmLicenseFetch.Payload(
+                    streamingSessionId,
+                    startTimestamp,
+                    trueTimeWrapper.currentTimeMillis,
+                    endReason,
+                    errorMessage,
+                    errorCode,
+                ),
+                extras,
+            )
         }
     }
 
@@ -116,7 +120,7 @@ internal class StreamingApiRepository(
         val startTimestamp = trueTimeWrapper.currentTimeMillis
         var errorMessage: String? = null
         var errorCode: String? = null
-        var endReason: EndReason? = null
+        lateinit var endReason: EndReason
         try {
             val ret =
                 when (forwardingMediaProduct.productType) {
@@ -155,8 +159,16 @@ internal class StreamingApiRepository(
                 }
             endReason = EndReason.COMPLETE
             return ret
-        } catch (e: CancellationException) {
-            throw e
+        } catch (cancellation: CancellationException) {
+            // Cancellation (e.g. user skip, or a request abandoned under slow network) is not a
+            // failure. We still report it with EndReason.OTHER to keep visibility into how long the
+            // request ran before being cancelled, then rethrow as-is to preserve coroutine
+            // cancellation semantics.
+            endReason = EndReason.OTHER
+            errorMessage = cancellation.cancellationEventMessage()
+            errorCode =
+                errorHandler.getErrorCode(cancellation, ErrorCodeFactory.Extra.PlaybackInfoFetch)
+            throw cancellation
         } catch (throwable: Throwable) {
             endReason = EndReason.ERROR
             errorMessage = throwable.stackTraceForPlaybackInfoFetchEvent()
@@ -164,21 +176,17 @@ internal class StreamingApiRepository(
                 errorHandler.getErrorCode(throwable, ErrorCodeFactory.Extra.PlaybackInfoFetch)
             throw IOException(throwable)
         } finally {
-            // endReason is only set when the request completed or failed; on cancellation it stays
-            // null and we skip reporting entirely.
-            endReason?.let {
-                eventReporter.report(
-                    PlaybackInfoFetch.Payload(
-                        streamingSessionId,
-                        startTimestamp,
-                        trueTimeWrapper.currentTimeMillis,
-                        it,
-                        errorMessage,
-                        errorCode,
-                    ),
-                    forwardingMediaProduct.extras,
-                )
-            }
+            eventReporter.report(
+                PlaybackInfoFetch.Payload(
+                    streamingSessionId,
+                    startTimestamp,
+                    trueTimeWrapper.currentTimeMillis,
+                    endReason,
+                    errorMessage,
+                    errorCode,
+                ),
+                forwardingMediaProduct.extras,
+            )
         }
     }
 
@@ -209,6 +217,14 @@ internal class StreamingApiRepository(
                     "ProductType ${forwardingMediaProduct.productType} can't be offlined."
                 )
         }
+
+    /**
+     * A concise message for a cancelled request. We deliberately avoid the full stack trace here:
+     * cancellations are frequent (every skip/seek) and we only want a clear marker that the request
+     * was cancelled, not a large payload.
+     */
+    private fun Throwable.cancellationEventMessage() =
+        (cause ?: this).message ?: "Request cancelled"
 
     private fun Throwable.stackTraceForPlaybackInfoFetchEvent(): String {
         val stackTrace = stackTraceToString()

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
@@ -29,6 +29,7 @@ import com.tidal.sdk.player.streamingapi.StreamingApi
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
 import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackMode
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody
@@ -146,6 +147,52 @@ internal class StreamingApiRepositoryTest {
                 ),
                 emptyMap(),
             )
+    }
+
+    @Test
+    fun getDrmLicenseOnCancellationRethrowsAndDoesNotReport() = runBlocking {
+        val streamingSessionId = "streamingSessionId"
+        val licenseUrl = "licenseUrl"
+        val payload = "fake_request_data".toByteArray()
+        val cancellationException = CancellationException("cancelled")
+        whenever(trueTimeWrapper.currentTimeMillis).thenReturn(1L)
+        whenever(streamingApi.getDrmLicense(licenseUrl, payload)) doThrow cancellationException
+
+        assertFailure {
+                streamingApiRepository.getDrmLicense(
+                    licenseUrl,
+                    payload,
+                    streamingSessionId,
+                    emptyMap(),
+                )
+            }
+            .isSameInstanceAs(cancellationException)
+
+        verifyNoInteractions(eventReporter)
+        verifyNoInteractions(mediaDrmCallbackExceptionFactory)
+    }
+
+    @Test
+    fun getPlaybackInfoForStreamingOnCancellationRethrowsAndDoesNotReport() = runBlocking {
+        val streamingSessionId = "streamingSessionId"
+        val productId = "33"
+        val mediaProduct =
+            mock<ForwardingMediaProduct<*>> {
+                on { it.productId } doReturn productId
+                on { it.productType } doReturn ProductType.UC
+            }
+        val cancellationException = CancellationException("cancelled")
+        whenever(trueTimeWrapper.currentTimeMillis).thenReturn(1L)
+        whenever(streamingApi.getUCPlaybackInfo(productId, streamingSessionId))
+            .thenThrow(cancellationException)
+
+        assertFailure {
+                streamingApiRepository.getPlaybackInfoForStreaming(streamingSessionId, mediaProduct)
+            }
+            .isSameInstanceAs(cancellationException)
+
+        verifyNoInteractions(eventReporter)
+        verifyNoInteractions(errorHandler)
     }
 
     @ParameterizedTest

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/StreamingApiRepositoryTest.kt
@@ -150,13 +150,23 @@ internal class StreamingApiRepositoryTest {
     }
 
     @Test
-    fun getDrmLicenseOnCancellationRethrowsAndDoesNotReport() = runBlocking {
+    fun getDrmLicenseOnCancellationRethrowsAndReportsAsOther() = runBlocking {
+        val startTimestamp = 1L
+        val endTimestamp = -2L
         val streamingSessionId = "streamingSessionId"
         val licenseUrl = "licenseUrl"
         val payload = "fake_request_data".toByteArray()
+        val errorCode = "errorCode"
         val cancellationException = CancellationException("cancelled")
-        whenever(trueTimeWrapper.currentTimeMillis).thenReturn(1L)
+        whenever(trueTimeWrapper.currentTimeMillis).thenReturn(startTimestamp, endTimestamp)
         whenever(streamingApi.getDrmLicense(licenseUrl, payload)) doThrow cancellationException
+        whenever(
+                errorHandler.getErrorCode(
+                    cancellationException,
+                    ErrorCodeFactory.Extra.DrmLicenseFetch,
+                )
+            )
+            .thenReturn(errorCode)
 
         assertFailure {
                 streamingApiRepository.getDrmLicense(
@@ -168,31 +178,62 @@ internal class StreamingApiRepositoryTest {
             }
             .isSameInstanceAs(cancellationException)
 
-        verifyNoInteractions(eventReporter)
+        verify(eventReporter)
+            .report(
+                DrmLicenseFetch.Payload(
+                    streamingSessionId,
+                    startTimestamp,
+                    endTimestamp,
+                    EndReason.OTHER,
+                    "cancelled",
+                    errorCode,
+                ),
+                emptyMap(),
+            )
         verifyNoInteractions(mediaDrmCallbackExceptionFactory)
     }
 
     @Test
-    fun getPlaybackInfoForStreamingOnCancellationRethrowsAndDoesNotReport() = runBlocking {
+    fun getPlaybackInfoForStreamingOnCancellationRethrowsAndReportsAsOther() = runBlocking {
+        val startTimestamp = 1L
+        val endTimestamp = -2L
         val streamingSessionId = "streamingSessionId"
         val productId = "33"
+        val errorCode = "errorCode"
         val mediaProduct =
             mock<ForwardingMediaProduct<*>> {
                 on { it.productId } doReturn productId
                 on { it.productType } doReturn ProductType.UC
             }
         val cancellationException = CancellationException("cancelled")
-        whenever(trueTimeWrapper.currentTimeMillis).thenReturn(1L)
+        whenever(trueTimeWrapper.currentTimeMillis).thenReturn(startTimestamp, endTimestamp)
         whenever(streamingApi.getUCPlaybackInfo(productId, streamingSessionId))
             .thenThrow(cancellationException)
+        whenever(
+                errorHandler.getErrorCode(
+                    cancellationException,
+                    ErrorCodeFactory.Extra.PlaybackInfoFetch,
+                )
+            )
+            .thenReturn(errorCode)
 
         assertFailure {
                 streamingApiRepository.getPlaybackInfoForStreaming(streamingSessionId, mediaProduct)
             }
             .isSameInstanceAs(cancellationException)
 
-        verifyNoInteractions(eventReporter)
-        verifyNoInteractions(errorHandler)
+        verify(eventReporter)
+            .report(
+                PlaybackInfoFetch.Payload(
+                    streamingSessionId,
+                    startTimestamp,
+                    endTimestamp,
+                    EndReason.OTHER,
+                    "cancelled",
+                    errorCode,
+                ),
+                emptyMap(),
+            )
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Why
`PlaybackInfo` and DRM license fetches are cancelled as a normal part of playback — every track skip and seek tears down the in-flight load via `PlaybackInfoLoadable.cancelLoad`. These cancellations were recorded as real failures, emitting large volumes of `PlaybackInfoFetch`/`DrmLicenseFetch` **ERROR** events that each carried a full `CancellationException` stack trace, drowning out genuine errors in the logs.

Simply dropping cancelled fetches (the first approach) went too far the other way: it lost visibility into requests abandoned under bad network — e.g. a user skipping while the player retries for >60s would produce zero events. So cancellations are reported, just not as errors.

Linear: TM-1550

## What
- Report cancelled fetches with `EndReason.OTHER` (not `ERROR`) and a concise "cancelled" message instead of the full stack trace, keeping `startTimestamp`/`endTimestamp` so we retain how long the request ran before cancellation.
- Catch `CancellationException` in `getPlaybackInfoForStreaming` and `getDrmLicense` and rethrow it as-is (no `IOException`/`MediaDrmCallbackException` wrapping) to preserve coroutine cancellation semantics.
- Genuine failures still report `EndReason.ERROR` with the stack trace / message and the wrapped rethrow, unchanged.
- Add unit tests covering the cancellation path for both methods.

## iOS parity
Matches the iOS SDK, which reports `PlaybackInfoFetch`/`DrmLicenseFetch` with `EndReason.OTHER` on cancellation (`endReason: error is CancellationError ? .OTHER : .ERROR` in `PlaybackInfoFetcher.swift` and `FairPlayLicenseFetcher.swift`), still sending the event and rethrowing.

## Risk Assessment
Low — scoped to the cancellation path of two fetch methods. Success and error reporting are unchanged, and `PlaybackInfoLoadable` already swallows the rethrown cancellation so playback behaviour is unaffected.
