### PR TITLE
Bump player to 0.0.69 with changelog

### DIFF
--- a/player/CHANGELOG.md
+++ b/player/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.69] - 2026-07-01
+
+### Fixed
+- Report cancelled `PlaybackInfo` and DRM license fetches with `EndReason.OTHER` instead of `EndReason.ERROR`, and rethrow `CancellationException` so normal cancellations (e.g. track skips) are no longer reported as fetch errors.
+
 ## [0.0.68] - 2026-06-24
 
 ### Changed

--- a/player/gradle.properties
+++ b/player/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Player module encapsulates the playback functionality of TIDAL media products.
-version=0.0.68
+version=0.0.69


### PR DESCRIPTION
## Why
Release the cancellation-reporting fix merged in #349. The player module needs a version bump and changelog entry so the change is published.

## What
- Bump `player` version `0.0.68` → `0.0.69`.
- Add a `0.0.69` changelog entry for reporting cancelled `PlaybackInfo`/DRM license fetches with `EndReason.OTHER` instead of `EndReason.ERROR`.

## Risk Assessment
Low — version/changelog only, no code changes.
