### PR TITLE
Fixed Dolby Atmos selection in adaptive DASH playback

### DIFF
--- a/player/CHANGELOG.md
+++ b/player/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.70] - 2026-09-04
+
+### Fixed
+- Fixed Dolby Atmos selection in adaptive DASH playback
+
 ## [0.0.69] - 2026-07-01
 
 ### Fixed

--- a/player/gradle.properties
+++ b/player/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Player module encapsulates the playback functionality of TIDAL media products.
-version=0.0.69
+version=0.0.70

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ExtendedExoPlayerModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/ExtendedExoPlayerModule.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.PriorityTaskManager
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
@@ -21,6 +22,7 @@ import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayer
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayerState
 import com.tidal.sdk.player.playbackengine.player.ExtendedExoPlayerStateUpdateRunnable
+import com.tidal.sdk.player.playbackengine.player.trackselection.TidalTrackSelectionFactory
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
@@ -36,7 +38,8 @@ internal object ExtendedExoPlayerModule {
 
     @Provides
     @Reusable
-    fun trackSelectionFactory(): ExoTrackSelection.Factory = AdaptiveTrackSelection.Factory()
+    fun trackSelectionFactory(): ExoTrackSelection.Factory =
+        TidalTrackSelectionFactory(AdaptiveTrackSelection.Factory())
 
     @Provides
     @Reusable
@@ -51,6 +54,9 @@ internal object ExtendedExoPlayerModule {
                     .setAllowAudioMixedMimeTypeAdaptiveness(true)
                     .setAllowAudioMixedSampleRateAdaptiveness(true)
                     .setAllowAudioMixedChannelCountAdaptiveness(true)
+                    // E-AC-3 is only present in manifests when immersive audio was requested, so
+                    // it is always preferred.
+                    .setPreferredAudioMimeTypes(MimeTypes.AUDIO_E_AC3_JOC, MimeTypes.AUDIO_E_AC3)
                     .build()
         }
 

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/PlayerRenderersFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/PlayerRenderersFactory.kt
@@ -16,6 +16,14 @@ internal class PlayerRenderersFactory(
     private val fallbackAudioRendererFactory: FallbackAudioRendererFactory,
 ) : RenderersFactory {
 
+    /**
+     * The order of audio renderers matters: ExoPlayer's MappingTrackSelector assigns an entire
+     * track group to a single renderer and breaks format-support ties by array order. Mixed-format
+     * adaptive groups (e.g. E-AC-3 JOC + FLAC + AAC) must map to the MediaCodec audio renderer, so
+     * it is registered before the libflac renderer. FLAC-only groups on devices whose platform FLAC
+     * decoder is missing still fall through to libflac, as MediaCodec reports them unsupported
+     * there.
+     */
     override fun createRenderers(
         eventHandler: Handler,
         videoRendererEventListener: VideoRendererEventListener,
@@ -25,8 +33,8 @@ internal class PlayerRenderersFactory(
     ) =
         arrayOf(
                 mediaCodecVideoRendererFactory.create(eventHandler, videoRendererEventListener),
-                libflacAudioRendererFactory?.create(eventHandler, audioRendererEventListener),
                 fallbackAudioRendererFactory.create(eventHandler, audioRendererEventListener),
+                libflacAudioRendererFactory?.create(eventHandler, audioRendererEventListener),
             )
             .filterNotNull()
             .toTypedArray()

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/trackselection/TidalTrackSelectionFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/trackselection/TidalTrackSelectionFactory.kt
@@ -1,0 +1,55 @@
+package com.tidal.sdk.player.playbackengine.player.trackselection
+
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Timeline
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection
+import androidx.media3.exoplayer.upstream.BandwidthMeter
+
+/**
+ * Deterministically prefers E-AC-3 (Dolby Atmos) representations in adaptive DASH manifests that
+ * expose a single adaptation set mixing E-AC-3 (JOC) with stereo representations (FLAC/AAC).
+ *
+ * E-AC-3 is only requested from the trackManifests API when immersive audio is enabled, so its
+ * presence in a manifest already expresses the user's intent: whenever it is selectable, it should
+ * play.
+ *
+ * The [DefaultTrackSelector][androidx.media3.exoplayer.trackselection.DefaultTrackSelector] is
+ * configured with mixed MIME type/sample rate/channel count adaptiveness, so it produces a single
+ * adaptive selection over all representations, ordered purely by declared bandwidth. Whether Atmos
+ * plays would then depend on the throughput estimate and could change mid-track. Instead, this
+ * factory pins such definitions to the E-AC-3 representations before the adaptive selection is
+ * created. Definitions without E-AC-3 tracks are left untouched, keeping the existing FLAC/AAC
+ * quality ladder, as are E-AC-3-only definitions. Devices that cannot play E-AC-3 are unaffected:
+ * the track selector excludes renderer-unsupported tracks from adaptive definitions before this
+ * factory runs.
+ */
+internal class TidalTrackSelectionFactory(private val delegate: ExoTrackSelection.Factory) :
+    ExoTrackSelection.Factory {
+
+    override fun createTrackSelections(
+        definitions: Array<out ExoTrackSelection.Definition?>,
+        bandwidthMeter: BandwidthMeter,
+        mediaPeriodId: MediaSource.MediaPeriodId,
+        timeline: Timeline,
+    ): Array<ExoTrackSelection?> {
+        val adjustedDefinitions = Array(definitions.size) { definitions[it]?.preferringEac3() }
+        return delegate.createTrackSelections(
+            adjustedDefinitions,
+            bandwidthMeter,
+            mediaPeriodId,
+            timeline,
+        )
+    }
+
+    private fun ExoTrackSelection.Definition.preferringEac3(): ExoTrackSelection.Definition {
+        val eac3Tracks = tracks.filter { isEac3(group.getFormat(it).sampleMimeType) }
+        if (eac3Tracks.isEmpty() || eac3Tracks.size == tracks.size) {
+            return this
+        }
+        return ExoTrackSelection.Definition(group, eac3Tracks.toIntArray(), type)
+    }
+
+    private fun isEac3(sampleMimeType: String?) =
+        MimeTypes.AUDIO_E_AC3_JOC == sampleMimeType || MimeTypes.AUDIO_E_AC3 == sampleMimeType
+}

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/PlayerRenderersFactoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/player/renderer/PlayerRenderersFactoryTest.kt
@@ -71,7 +71,7 @@ internal class PlayerRenderersFactoryTest {
 
         assertThat(actual)
             .isEqualTo(
-                arrayOf(mediaCodecVideoRenderer, libflacAudioRenderer, fallbackAudioRenderer)
+                arrayOf(mediaCodecVideoRenderer, fallbackAudioRenderer, libflacAudioRenderer)
                     .filterNotNull()
                     .toTypedArray()
             )

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/player/trackselection/TidalTrackSelectionFactoryTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/player/trackselection/TidalTrackSelectionFactoryTest.kt
@@ -1,0 +1,181 @@
+package com.tidal.sdk.player.playbackengine.player.trackselection
+
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Timeline
+import androidx.media3.common.TrackGroup
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection
+import androidx.media3.exoplayer.upstream.BandwidthMeter
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * The fixture mirrors a real adaptive DASH manifest from the trackManifests API: a single
+ * adaptation set with EAC3_JOC (signalled as plain codecs="ec-3", so parsed as audio/eac3, 769
+ * kbps, 48 kHz) plus FLAC, AACLC and HEAACV1 stereo representations at 44.1 kHz.
+ */
+internal class TidalTrackSelectionFactoryTest {
+
+    private val delegate = mock<ExoTrackSelection.Factory>()
+    private val tidalTrackSelectionFactory = TidalTrackSelectionFactory(delegate)
+
+    private val bandwidthMeter = mock<BandwidthMeter>()
+    private val mediaPeriodId = MediaSource.MediaPeriodId("periodUid")
+    private val timeline = Timeline.EMPTY
+
+    private val eac3Format =
+        Format.Builder()
+            .setId("eac3joc")
+            .setSampleMimeType(MimeTypes.AUDIO_E_AC3)
+            .setCodecs("ec-3")
+            .setAverageBitrate(769_000)
+            .setPeakBitrate(769_000)
+            .setSampleRate(48_000)
+            .setChannelCount(2)
+            .build()
+    private val flacFormat =
+        Format.Builder()
+            .setId("flac")
+            .setSampleMimeType(MimeTypes.AUDIO_FLAC)
+            .setCodecs("flac")
+            .setAverageBitrate(266_000)
+            .setPeakBitrate(266_000)
+            .setSampleRate(44_100)
+            .setChannelCount(2)
+            .build()
+    private val aacLcFormat =
+        Format.Builder()
+            .setId("aaclc")
+            .setSampleMimeType(MimeTypes.AUDIO_AAC)
+            .setCodecs("mp4a.40.2")
+            .setAverageBitrate(322_000)
+            .setPeakBitrate(322_000)
+            .setSampleRate(44_100)
+            .setChannelCount(2)
+            .build()
+    private val heAacV1Format =
+        Format.Builder()
+            .setId("heaacv1")
+            .setSampleMimeType(MimeTypes.AUDIO_AAC)
+            .setCodecs("mp4a.40.5")
+            .setAverageBitrate(97_000)
+            .setPeakBitrate(97_000)
+            .setSampleRate(44_100)
+            .setChannelCount(2)
+            .build()
+
+    private val mixedTrackGroup = trackGroupOf(eac3Format, flacFormat, aacLcFormat, heAacV1Format)
+
+    /**
+     * [TrackGroup]'s constructor is not usable in unit tests (it relies on unmocked android.jar
+     * methods), so a mock serving the same formats is used instead.
+     */
+    private fun trackGroupOf(vararg formats: Format) =
+        mock<TrackGroup> {
+            formats.forEachIndexed { index, format -> on { getFormat(index) } doReturn format }
+        }
+
+    private fun createTrackSelections(
+        definitions: Array<ExoTrackSelection.Definition?>
+    ): Array<out ExoTrackSelection.Definition?> {
+        val expectedResult = emptyArray<ExoTrackSelection?>()
+        whenever(
+                delegate.createTrackSelections(
+                    any(),
+                    eq(bandwidthMeter),
+                    eq(mediaPeriodId),
+                    eq(timeline),
+                )
+            )
+            .doReturn(expectedResult)
+
+        val actualResult =
+            tidalTrackSelectionFactory.createTrackSelections(
+                definitions,
+                bandwidthMeter,
+                mediaPeriodId,
+                timeline,
+            )
+
+        val definitionsCaptor = argumentCaptor<Array<ExoTrackSelection.Definition?>>()
+        verify(delegate)
+            .createTrackSelections(
+                definitionsCaptor.capture(),
+                eq(bandwidthMeter),
+                eq(mediaPeriodId),
+                eq(timeline),
+            )
+        assertThat(actualResult).isSameInstanceAs(expectedResult)
+        return definitionsCaptor.firstValue
+    }
+
+    @Test
+    fun mixedDefinitionIsPinnedToEac3() {
+        val definition = ExoTrackSelection.Definition(mixedTrackGroup, 0, 1, 2, 3)
+
+        val adjustedDefinitions = createTrackSelections(arrayOf(definition))
+
+        val adjusted = adjustedDefinitions[0]!!
+        assertThat(adjusted.group).isSameInstanceAs(mixedTrackGroup)
+        assertThat(adjusted.tracks.toList()).isEqualTo(listOf(0))
+        assertThat(adjusted.type).isEqualTo(definition.type)
+    }
+
+    @Test
+    fun mixedDefinitionRecognisesEac3JocSampleMimeType() {
+        val eac3JocFormat =
+            eac3Format.buildUpon().setSampleMimeType(MimeTypes.AUDIO_E_AC3_JOC).build()
+        val trackGroup = trackGroupOf(flacFormat, eac3JocFormat)
+        val definition = ExoTrackSelection.Definition(trackGroup, 0, 1)
+
+        val adjustedDefinitions = createTrackSelections(arrayOf(definition))
+
+        assertThat(adjustedDefinitions[0]!!.tracks.toList()).isEqualTo(listOf(1))
+    }
+
+    @Test
+    fun eac3OnlyDefinitionIsUntouched() {
+        val definition = ExoTrackSelection.Definition(trackGroupOf(eac3Format), 0)
+
+        val adjustedDefinitions = createTrackSelections(arrayOf(definition))
+
+        assertThat(adjustedDefinitions[0]).isSameInstanceAs(definition)
+    }
+
+    @Test
+    fun definitionWithoutEac3IsUntouched() {
+        val definition =
+            ExoTrackSelection.Definition(
+                trackGroupOf(flacFormat, aacLcFormat, heAacV1Format),
+                0,
+                1,
+                2,
+            )
+
+        val adjustedDefinitions = createTrackSelections(arrayOf(definition))
+
+        assertThat(adjustedDefinitions[0]).isSameInstanceAs(definition)
+    }
+
+    @Test
+    fun nullDefinitionsArePreserved() {
+        val definition = ExoTrackSelection.Definition(mixedTrackGroup, 0, 1, 2, 3)
+
+        val adjustedDefinitions = createTrackSelections(arrayOf(null, definition, null))
+
+        assertThat(adjustedDefinitions[0]).isNull()
+        assertThat(adjustedDefinitions[1]!!.tracks.toList()).isEqualTo(listOf(0))
+        assertThat(adjustedDefinitions[2]).isNull()
+    }
+}


### PR DESCRIPTION
Dolby Atmos (EAC3_JOC) was never selected when playing adaptive DASH manifests that mix EAC3_JOC with FLAC/AAC in a single adaptation set:

- `LibflacAudioRenderer` was registered before `MediaCodecAudioRenderer`, so mixed track groups were mapped to the libflac renderer, leaving only FLAC tracks playable.
- Within a mixed group, the adaptive selection picked tracks purely by bandwidth, so whether Atmos played depended on network speed.

**Fix**:
- Register `MediaCodecAudioRenderer` before `LibflacAudioRenderer`, so mixed groups map to the renderer that can play all formats. FLAC-only groups still fall through to libflac where the platform decoder is missing.
- Add `TidalTrackSelectionFactory`, which pins the selection to EAC3 tracks whenever a group contains them, and prefer EAC3 MIME types in the track selector. EAC3_JOC is only present in a manifest when the caller requested immersive audio, so its presence implies user intent.