### PR TITLE
TidalAPI: accept generic create dry-run responses

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/OptionalCreateResponseConverterFactory.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/OptionalCreateResponseConverterFactory.kt
@@ -1,0 +1,65 @@
+package com.tidal.sdk.tidalapi.networking
+
+import com.tidal.sdk.tidalapi.generated.models.AppreciationsCreateSingleResourceDataDocument
+import com.tidal.sdk.tidalapi.generated.models.ArtistsCreateSingleResourceDataDocument
+import java.lang.reflect.Type
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import retrofit2.Converter
+import retrofit2.Retrofit
+
+/**
+ * Lets dry-run-aware resource-create calls return a generic JSON:API success document.
+ *
+ * These endpoints normally return a typed `*CreateSingleResourceDataDocument`. A dry run may
+ * instead return a generic JSON:API document. This factory maps that document to an absent typed
+ * body while leaving ordinary typed create responses strict.
+ */
+internal class OptionalCreateResponseConverterFactory(
+    private val json: Json,
+    private val delegate: Converter.Factory,
+) : Converter.Factory() {
+
+    override fun responseBodyConverter(
+        type: Type,
+        annotations: Array<Annotation>,
+        retrofit: Retrofit,
+    ): Converter<ResponseBody, *>? {
+        if (getRawType(type).simpleName !in DRY_RUN_CREATE_RESPONSE_TYPES) return null
+
+        val typedConverter =
+            delegate.responseBodyConverter(type, annotations, retrofit) ?: return null
+
+        return Converter { body ->
+            val contentType = body.contentType()
+            val payload = body.bytes()
+            val text = payload.decodeToString()
+
+            if (text.isGenericJsonApiSuccessDocument()) {
+                null
+            } else {
+                typedConverter.convert(payload.toResponseBody(contentType))
+            }
+        }
+    }
+
+    private fun String.isGenericJsonApiSuccessDocument(): Boolean {
+        val document =
+            runCatching { json.parseToJsonElement(this) as? JsonObject }.getOrNull() ?: return false
+
+        if ("errors" in document) return false
+
+        return document["data"] == JsonNull || ("data" !in document && "meta" in document)
+    }
+
+    private companion object {
+        val DRY_RUN_CREATE_RESPONSE_TYPES =
+            setOf(
+                AppreciationsCreateSingleResourceDataDocument::class.java.simpleName,
+                ArtistsCreateSingleResourceDataDocument::class.java.simpleName,
+            )
+    }
+}

--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -40,10 +40,14 @@ constructor(
         }
     }
 
+    private val jsonSerializer = createJsonSerializer()
+    private val jsonConverterFactory =
+        jsonSerializer.asConverterFactory("application/json".toMediaType())
     private val converterFactories: List<Converter.Factory> =
         listOf(
             ScalarsConverterFactory.create(),
-            createJsonSerializer().asConverterFactory("application/json".toMediaType()),
+            OptionalCreateResponseConverterFactory(jsonSerializer, jsonConverterFactory),
+            jsonConverterFactory,
         )
 
     private fun provideOkHttpClient(credentialsProvider: CredentialsProvider): OkHttpClient =

--- a/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/CreateDryRunResponseCompatibilityTest.kt
+++ b/tidalapi/src/test/kotlin/com/tidal/sdk/tidalapi/networking/CreateDryRunResponseCompatibilityTest.kt
@@ -1,0 +1,96 @@
+package com.tidal.sdk.tidalapi.networking
+
+import com.tidal.sdk.tidalapi.generated.models.ArtistsCreateSingleResourceDataDocument
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+import retrofit2.http.POST
+
+class CreateDryRunResponseCompatibilityTest {
+
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private interface TestApi {
+        @POST("artists")
+        suspend fun createArtist(): Response<ArtistsCreateSingleResourceDataDocument>
+    }
+
+    private fun api(): TestApi =
+        RetrofitProvider(retryPolicy = null)
+            .provideRetrofit(server.url("/").toString(), FakeCredentialsProvider())
+            .create(TestApi::class.java)
+
+    @Test
+    fun `accepts generic JSON API success documents for 200 and 201`() = runTest {
+        listOf(200, 201).forEach { status ->
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(status)
+                    .setHeader("Content-Type", "application/vnd.api+json")
+                    .setBody("""{"links":{"self":"/artists"},"meta":{}}""")
+            )
+
+            val response = api().createArtist()
+
+            assertEquals(status, response.code())
+            assertNull(response.body())
+        }
+    }
+
+    @Test
+    fun `continues to decode an ordinary typed create response`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(201)
+                .setHeader("Content-Type", "application/vnd.api+json")
+                .setBody(
+                    """
+                    {
+                      "data": {"id": "123", "type": "artists"},
+                      "links": {"self": "/artists/123"}
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        val response = api().createArtist()
+
+        assertEquals(201, response.code())
+        assertEquals("123", response.body()?.data?.id)
+    }
+
+    @Test
+    fun `does not hide a malformed typed create response`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/vnd.api+json")
+                .setBody("""{"data":{"type":"artists"},"links":{"self":"/artists"}}""")
+        )
+
+        val result = runCatching { api().createArtist() }
+
+        assertFalse(result.isSuccess)
+        assertNotNull(result.exceptionOrNull())
+    }
+}


### PR DESCRIPTION
## Summary

- Accept generic JSON:API success documents for dry-run-aware Artists and Appreciations creates.
- Support either a 200 or 201 response with a payload, representing a generic success as an absent typed create body.
- Keep normal typed create responses strict and reject malformed typed documents.
- Limit the compatibility behavior to the two dry-run-aware create response types.

## Context

A server follow-up will replace the legacy bodyless create dry-run response with a generic JSON:API payload. Retrofit already accepts every successful 2xx status; this closes only the response-conversion gap.

There are currently no first-party Android call sites for artistsPost or appreciationsPost, but the shared SDK boundary should be compatible before the server response changes.

## Verification

- ./gradlew :tidalapi:testDebugUnitTest :tidalapi:lint
- static-analysis/run-ktfmt.sh -l