### PR TITLE
TIDE-2308: Add offline Widevine license API

### DIFF
--- a/player/CHANGELOG.md
+++ b/player/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.72] - 2026-08-14
+
+### Added
+- Added a public Widevine offline-license provider for acquiring, renewing, and releasing persistent licenses during downloads.
+
 ## [0.0.71] - 2026-08-13
 
 ### Changed

--- a/player/gradle.properties
+++ b/player/gradle.properties
@@ -1,2 +1,2 @@
 projectDescription=The Player module encapsulates the playback functionality of TIDAL media products.
-version=0.0.71
+version=0.0.72

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/PlaybackEngineModuleRoot.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/PlaybackEngineModuleRoot.kt
@@ -12,6 +12,7 @@ import com.tidal.sdk.player.playbackengine.di.DaggerExoPlayerPlaybackEngineCompo
 import com.tidal.sdk.player.playbackengine.model.AssetTimeoutConfig
 import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
 import com.tidal.sdk.player.playbackengine.model.Event
+import com.tidal.sdk.player.playbackengine.offline.OfflineLicenseProvider
 import com.tidal.sdk.player.playbackengine.offline.cache.OfflineCacheProvider
 import com.tidal.sdk.player.playbackengine.playbackprivilege.PlaybackPrivilegeProvider
 import com.tidal.sdk.player.playbackengine.player.CacheProvider
@@ -78,6 +79,7 @@ class PlaybackEngineModuleRoot(
                 coroutineScope,
             )
     val playbackEngine = component.playbackEngine
+    val offlineLicenseProvider: OfflineLicenseProvider = component.offlineLicenseProvider
 
     companion object {
 

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/di/ExoPlayerPlaybackEngineComponent.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/di/ExoPlayerPlaybackEngineComponent.kt
@@ -13,6 +13,7 @@ import com.tidal.sdk.player.playbackengine.PlaybackEngine
 import com.tidal.sdk.player.playbackengine.model.AssetTimeoutConfig
 import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
 import com.tidal.sdk.player.playbackengine.model.Event
+import com.tidal.sdk.player.playbackengine.offline.OfflineLicenseProvider
 import com.tidal.sdk.player.playbackengine.offline.cache.OfflineCacheProvider
 import com.tidal.sdk.player.playbackengine.playbackprivilege.PlaybackPrivilegeProvider
 import com.tidal.sdk.player.playbackengine.player.CacheProvider
@@ -34,6 +35,7 @@ import okhttp3.OkHttpClient
 interface ExoPlayerPlaybackEngineComponent {
 
     val playbackEngine: PlaybackEngine
+    val offlineLicenseProvider: OfflineLicenseProvider
 
     @Component.Factory
     interface Factory {

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmMode.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/DrmMode.kt
@@ -8,4 +8,13 @@ internal sealed class DrmMode {
      * key.
      */
     object Streaming : DrmMode()
+
+    /** Drm mode for acquiring a persistent license during an offline download. */
+    object OfflineAcquisition : DrmMode()
+
+    /** Drm mode for renewing an existing persistent offline license. */
+    object OfflineRenewal : DrmMode()
+
+    /** Drm mode for releasing an existing persistent offline license. */
+    object OfflineRelease : DrmMode()
 }

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/OfflineLicenseHelperFactory.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/OfflineLicenseHelperFactory.kt
@@ -1,0 +1,10 @@
+package com.tidal.sdk.player.playbackengine.drm
+
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
+import androidx.media3.exoplayer.drm.DrmSessionEventListener
+import androidx.media3.exoplayer.drm.OfflineLicenseHelper
+
+internal class OfflineLicenseHelperFactory {
+    fun create(drmSessionManager: DefaultDrmSessionManager) =
+        OfflineLicenseHelper(drmSessionManager, DrmSessionEventListener.EventDispatcher())
+}

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/OfflineLicenseProviderDefault.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/OfflineLicenseProviderDefault.kt
@@ -1,0 +1,110 @@
+package com.tidal.sdk.player.playbackengine.drm
+
+import androidx.annotation.OptIn
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
+import com.tidal.sdk.player.common.model.Extras
+import com.tidal.sdk.player.commonandroid.Base64Codec
+import com.tidal.sdk.player.playbackengine.offline.OfflineLicenseProvider
+import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+@OptIn(UnstableApi::class)
+internal class OfflineLicenseProviderDefault(
+    private val drmSessionManagerBuilder: DefaultDrmSessionManager.Builder,
+    private val drmCallbackFactory: TidalMediaDrmCallbackFactory,
+    private val offlineLicenseHelperFactory: OfflineLicenseHelperFactory,
+    private val base64Codec: Base64Codec,
+    private val coroutineDispatcher: CoroutineDispatcher,
+) : OfflineLicenseProvider {
+
+    override suspend fun acquireOfflineLicense(
+        playbackInfo: PlaybackInfo,
+        drmFormat: Format,
+        extras: Extras?,
+    ): String? =
+        withContext(coroutineDispatcher) {
+            if (drmFormat.drmInitData == null) {
+                return@withContext null
+            }
+
+            val helper =
+                createHelper(
+                    playbackInfo = playbackInfo,
+                    mode = DrmMode.OfflineAcquisition,
+                    extras = extras,
+                )
+            try {
+                helper.downloadLicense(drmFormat).requireLicense().encode()
+            } finally {
+                helper.release()
+            }
+        }
+
+    override suspend fun renewOfflineLicense(
+        playbackInfo: PlaybackInfo,
+        offlineLicense: String,
+        extras: Extras?,
+    ): String =
+        withContext(coroutineDispatcher) {
+            val helper =
+                createHelper(
+                    playbackInfo = playbackInfo,
+                    mode = DrmMode.OfflineRenewal,
+                    extras = extras,
+                )
+            try {
+                helper.renewLicense(offlineLicense.decode()).requireLicense().encode()
+            } finally {
+                helper.release()
+            }
+        }
+
+    override suspend fun releaseOfflineLicense(offlineLicense: String) {
+        withContext(coroutineDispatcher) {
+            val callback = drmCallbackFactory.create("", "", DrmMode.OfflineRelease, null)
+            val helper =
+                offlineLicenseHelperFactory.create(drmSessionManagerBuilder.build(callback))
+            try {
+                helper.releaseLicense(offlineLicense.decode())
+            } finally {
+                helper.release()
+            }
+        }
+    }
+
+    private fun createHelper(playbackInfo: PlaybackInfo, mode: DrmMode, extras: Extras?) =
+        offlineLicenseHelperFactory.create(
+            drmSessionManagerBuilder.build(
+                drmCallbackFactory.create(
+                    playbackInfo.requireLicenseUrl(),
+                    playbackInfo.streamingSessionId,
+                    mode,
+                    extras,
+                )
+            )
+        )
+
+    private fun PlaybackInfo.requireLicenseUrl(): String {
+        require(this is PlaybackInfo.Track || this is PlaybackInfo.Video) {
+            "Offline licenses are only supported for tracks and videos."
+        }
+        return requireNotNull(licenseUrl?.takeIf(String::isNotBlank)) {
+            "A license URL is required for protected offline content."
+        }
+    }
+
+    private fun ByteArray?.requireLicense(): ByteArray {
+        check(!isNullOrEmpty()) { "Widevine did not return a persistent key-set ID." }
+        return requireNotNull(this)
+    }
+
+    private fun ByteArray.encode() = String(base64Codec.encode(this), Charsets.UTF_8)
+
+    private fun String.decode(): ByteArray {
+        require(isNotBlank()) { "The offline license must not be blank." }
+        return base64Codec.decode(toByteArray(Charsets.UTF_8))
+    }
+}

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallback.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallback.kt
@@ -39,7 +39,9 @@ internal class TidalMediaDrmCallback(
     override fun executeKeyRequest(uuid: UUID, request: ExoMediaDrm.KeyRequest): ByteArray {
         val drmLicense =
             when (mode) {
-                DrmMode.Streaming ->
+                DrmMode.Streaming,
+                DrmMode.OfflineAcquisition,
+                DrmMode.OfflineRenewal ->
                     runBlocking {
                         streamingApiRepository.getDrmLicense(
                             licenseUrl,
@@ -48,6 +50,7 @@ internal class TidalMediaDrmCallback(
                             extras,
                         )
                     }
+                DrmMode.OfflineRelease -> return request.data
             }
 
         return drmLicense.body()?.bytes()

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineLicenseProvider.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/offline/OfflineLicenseProvider.kt
@@ -1,0 +1,32 @@
+package com.tidal.sdk.player.playbackengine.offline
+
+import androidx.media3.common.Format
+import com.tidal.sdk.player.common.model.Extras
+import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
+
+/** Acquires and manages persistent Widevine licenses for downloaded media. */
+interface OfflineLicenseProvider {
+
+    /**
+     * Acquires a persistent license for [playbackInfo] and [drmFormat].
+     *
+     * [drmFormat] must come from the offline manifest selected for download. A Base64-encoded
+     * Widevine key-set ID is returned for the caller to persist alongside the downloaded media.
+     * DRM-free formats return `null`.
+     */
+    suspend fun acquireOfflineLicense(
+        playbackInfo: PlaybackInfo,
+        drmFormat: Format,
+        extras: Extras? = null,
+    ): String?
+
+    /** Renews [offlineLicense] and returns the replacement Base64-encoded key-set ID. */
+    suspend fun renewOfflineLicense(
+        playbackInfo: PlaybackInfo,
+        offlineLicense: String,
+        extras: Extras? = null,
+    ): String
+
+    /** Releases [offlineLicense] from the device's Widevine content decryption module. */
+    suspend fun releaseOfflineLicense(offlineLicense: String)
+}

--- a/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
+++ b/player/playback-engine/src/main/kotlin/com/tidal/sdk/player/playbackengine/player/di/MediaSourcererModule.kt
@@ -40,6 +40,8 @@ import com.tidal.sdk.player.playbackengine.di.ExoPlayerPlaybackEngineComponent
 import com.tidal.sdk.player.playbackengine.drm.DrmSessionManagerFactory
 import com.tidal.sdk.player.playbackengine.drm.DrmSessionManagerProviderFactory
 import com.tidal.sdk.player.playbackengine.drm.MediaDrmCallbackExceptionFactory
+import com.tidal.sdk.player.playbackengine.drm.OfflineLicenseHelperFactory
+import com.tidal.sdk.player.playbackengine.drm.OfflineLicenseProviderDefault
 import com.tidal.sdk.player.playbackengine.drm.TidalMediaDrmCallbackFactory
 import com.tidal.sdk.player.playbackengine.emu.EmuManifestFactory
 import com.tidal.sdk.player.playbackengine.error.ErrorHandler
@@ -60,6 +62,7 @@ import com.tidal.sdk.player.playbackengine.mediasource.loadable.PlaybackInfoLoad
 import com.tidal.sdk.player.playbackengine.mediasource.streamingsession.StreamingSession
 import com.tidal.sdk.player.playbackengine.model.AssetTimeoutConfig
 import com.tidal.sdk.player.playbackengine.offline.OfflineDrmHelper
+import com.tidal.sdk.player.playbackengine.offline.OfflineLicenseProvider
 import com.tidal.sdk.player.playbackengine.offline.OfflinePlayDataSourceFactoryHelper
 import com.tidal.sdk.player.playbackengine.offline.OfflinePlayDrmDataSourceFactoryHelper
 import com.tidal.sdk.player.playbackengine.offline.OfflineStorageProvider
@@ -424,6 +427,25 @@ internal object MediaSourcererModule {
         streamingApiRepository: StreamingApiRepository,
         @ExtendedExoPlayerComponent.Local okHttpClient: OkHttpClient,
     ) = TidalMediaDrmCallbackFactory(streamingApiRepository, okHttpClient)
+
+    @Provides @Reusable fun offlineLicenseHelperFactory() = OfflineLicenseHelperFactory()
+
+    @Provides
+    @Reusable
+    fun offlineLicenseProvider(
+        defaultDrmSessionManagerBuilder: DefaultDrmSessionManager.Builder,
+        tidalMediaDrmCallbackFactory: TidalMediaDrmCallbackFactory,
+        offlineLicenseHelperFactory: OfflineLicenseHelperFactory,
+        base64Codec: Base64Codec,
+        coroutineDispatcher: CoroutineDispatcher,
+    ): OfflineLicenseProvider =
+        OfflineLicenseProviderDefault(
+            defaultDrmSessionManagerBuilder,
+            tidalMediaDrmCallbackFactory,
+            offlineLicenseHelperFactory,
+            base64Codec,
+            coroutineDispatcher,
+        )
 
     @Provides
     @Reusable

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/drm/OfflineLicenseProviderDefaultTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/drm/OfflineLicenseProviderDefaultTest.kt
@@ -1,0 +1,135 @@
+package com.tidal.sdk.player.playbackengine.drm
+
+import androidx.media3.common.DrmInitData
+import androidx.media3.common.Format
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManager
+import androidx.media3.exoplayer.drm.OfflineLicenseHelper
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import com.tidal.sdk.player.commonandroid.Base64Codec
+import com.tidal.sdk.player.streamingapi.playbackinfo.model.PlaybackInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class OfflineLicenseProviderDefaultTest {
+
+    private val drmSessionManager = mock<DefaultDrmSessionManager>()
+    private val drmSessionManagerBuilder = mock<DefaultDrmSessionManager.Builder>()
+    private val drmCallback = mock<TidalMediaDrmCallback>()
+    private val drmCallbackFactory = mock<TidalMediaDrmCallbackFactory>()
+    private val offlineLicenseHelper = mock<OfflineLicenseHelper>()
+    private val offlineLicenseHelperFactory = mock<OfflineLicenseHelperFactory>()
+    private val base64Codec = mock<Base64Codec>()
+    private val offlineLicenseProvider =
+        OfflineLicenseProviderDefault(
+            drmSessionManagerBuilder,
+            drmCallbackFactory,
+            offlineLicenseHelperFactory,
+            base64Codec,
+            Dispatchers.Unconfined,
+        )
+
+    @Test
+    fun acquireOfflineLicenseReturnsNullForDrmFreeFormat() = runBlocking {
+        val playbackInfo = mock<PlaybackInfo.Track>()
+        val format = mock<Format> { on { drmInitData } doReturn null }
+
+        val actual = offlineLicenseProvider.acquireOfflineLicense(playbackInfo, format)
+
+        assertThat(actual).isNull()
+        verify(offlineLicenseHelperFactory, never()).create(any())
+    }
+
+    @Test
+    fun acquireOfflineLicenseReturnsEncodedPersistentKeySet() = runBlocking {
+        val playbackInfo =
+            mock<PlaybackInfo.Track> {
+                on { licenseUrl } doReturn "license-url"
+                on { streamingSessionId } doReturn "session-id"
+            }
+        val format = mock<Format> { on { drmInitData } doReturn mock<DrmInitData>() }
+        val keySetId = byteArrayOf(1, 2, 3)
+        arrangeHelper(DrmMode.OfflineAcquisition)
+        whenever(offlineLicenseHelper.downloadLicense(format)).thenReturn(keySetId)
+        whenever(base64Codec.encode(keySetId)).thenReturn("encoded-license".toByteArray())
+
+        val actual = offlineLicenseProvider.acquireOfflineLicense(playbackInfo, format)
+
+        assertThat(actual).isEqualTo("encoded-license")
+        verify(offlineLicenseHelper).release()
+    }
+
+    @Test
+    fun renewOfflineLicenseReturnsEncodedReplacementKeySet() = runBlocking {
+        val playbackInfo =
+            mock<PlaybackInfo.Video> {
+                on { licenseUrl } doReturn "license-url"
+                on { streamingSessionId } doReturn "session-id"
+            }
+        val oldKeySetId = byteArrayOf(1)
+        val renewedKeySetId = byteArrayOf(2)
+        arrangeHelper(DrmMode.OfflineRenewal)
+        whenever(base64Codec.decode("old-license".toByteArray())).thenReturn(oldKeySetId)
+        whenever(offlineLicenseHelper.renewLicense(oldKeySetId)).thenReturn(renewedKeySetId)
+        whenever(base64Codec.encode(renewedKeySetId)).thenReturn("renewed-license".toByteArray())
+
+        val actual = offlineLicenseProvider.renewOfflineLicense(playbackInfo, "old-license")
+
+        assertThat(actual).isEqualTo("renewed-license")
+        verify(offlineLicenseHelper).release()
+    }
+
+    @Test
+    fun releaseOfflineLicenseReleasesDecodedKeySet() = runBlocking {
+        val keySetId = byteArrayOf(1, 2, 3)
+        whenever(drmCallbackFactory.create("", "", DrmMode.OfflineRelease, null))
+            .thenReturn(drmCallback)
+        whenever(drmSessionManagerBuilder.build(drmCallback)).thenReturn(drmSessionManager)
+        whenever(offlineLicenseHelperFactory.create(drmSessionManager))
+            .thenReturn(offlineLicenseHelper)
+        whenever(base64Codec.decode("offline-license".toByteArray())).thenReturn(keySetId)
+
+        offlineLicenseProvider.releaseOfflineLicense("offline-license")
+
+        verify(offlineLicenseHelper).releaseLicense(keySetId)
+        verify(offlineLicenseHelper).release()
+    }
+
+    @Test
+    fun acquireOfflineLicenseReleasesHelperWhenAcquisitionFails() {
+        val playbackInfo =
+            mock<PlaybackInfo.Track> {
+                on { licenseUrl } doReturn "license-url"
+                on { streamingSessionId } doReturn "session-id"
+            }
+        val format = mock<Format> { on { drmInitData } doReturn mock<DrmInitData>() }
+        val expected = IllegalStateException("failed")
+        arrangeHelper(DrmMode.OfflineAcquisition)
+        whenever(offlineLicenseHelper.downloadLicense(format)).thenThrow(expected)
+
+        val actual =
+            assertThrows<IllegalStateException> {
+                runBlocking { offlineLicenseProvider.acquireOfflineLicense(playbackInfo, format) }
+            }
+
+        assertThat(actual).isEqualTo(expected)
+        verify(offlineLicenseHelper).release()
+    }
+
+    private fun arrangeHelper(mode: DrmMode) {
+        whenever(drmCallbackFactory.create("license-url", "session-id", mode, null))
+            .thenReturn(drmCallback)
+        whenever(drmSessionManagerBuilder.build(drmCallback)).thenReturn(drmSessionManager)
+        whenever(offlineLicenseHelperFactory.create(drmSessionManager))
+            .thenReturn(offlineLicenseHelper)
+    }
+}

--- a/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallbackTest.kt
+++ b/player/playback-engine/src/test/kotlin/com/tidal/sdk/player/playbackengine/drm/TidalMediaDrmCallbackTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 internal class TidalMediaDrmCallbackTest {
@@ -84,6 +85,28 @@ internal class TidalMediaDrmCallbackTest {
                 tidalMediaDrmCallback.executeKeyRequest(C.WIDEVINE_UUID, request)
             }
         assertThat(actual).isSameInstanceAs(expected)
+    }
+
+    @Test
+    fun executeKeyRequestWithOfflineReleaseReturnsTheCdmPayload() {
+        val request =
+            mock<ExoMediaDrm.KeyRequest> { on { data } doReturn "keyRequest".toByteArray() }
+        val callback =
+            TidalMediaDrmCallback(
+                streamingApiRepository,
+                streamingSessionId,
+                licenseUrl,
+                DrmMode.OfflineRelease,
+                okHttpClient,
+                lazy { provisionRequestBuilder },
+                lazy { provisionRequestBody },
+                emptyMap(),
+            )
+
+        val actual = callback.executeKeyRequest(C.WIDEVINE_UUID, request)
+
+        assertThat(actual).isSameInstanceAs(request.data)
+        verifyNoInteractions(streamingApiRepository)
     }
 
     @Test

--- a/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/Player.kt
@@ -92,6 +92,9 @@ class Player(
             )
     val configuration = playerComponent.configuration
     val playbackEngine = playerComponent.playbackEngine
+
+    /** Manages persistent Widevine licenses for media downloaded by the host application. */
+    val offlineLicenseProvider = playerComponent.offlineLicenseProvider
     val streamingApi = playerComponent.streamingApi
     private val streamingPrivileges = playerComponent.streamingPrivileges
 

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/PlaybackEngineModule.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/PlaybackEngineModule.kt
@@ -13,6 +13,7 @@ import com.tidal.sdk.player.playbackengine.PlaybackEngineModuleRoot
 import com.tidal.sdk.player.playbackengine.model.AssetTimeoutConfig
 import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
 import com.tidal.sdk.player.playbackengine.model.Event
+import com.tidal.sdk.player.playbackengine.offline.OfflineLicenseProvider
 import com.tidal.sdk.player.playbackengine.playbackprivilege.PlaybackPrivilegeProvider
 import com.tidal.sdk.player.playbackengine.player.CacheProvider
 import com.tidal.sdk.player.streamingapi.StreamingApi
@@ -38,7 +39,7 @@ internal object PlaybackEngineModule {
 
     @Provides
     @Singleton
-    fun playbackEngine(
+    fun playbackEngineModuleRoot(
         context: Context,
         connectivityManager: ConnectivityManager,
         @Named("enableDecoderFallback") enableDecoderFallback: Boolean,
@@ -61,31 +62,36 @@ internal object PlaybackEngineModule {
         base64Codec: Base64Codec,
         coroutineDispatcher: CoroutineDispatcher,
         coroutineScope: CoroutineScope,
-    ) =
+    ): PlaybackEngineModuleRoot =
         PlaybackEngineModuleRoot(
-                context,
-                connectivityManager,
-                enableDecoderFallback,
-                events,
-                bufferConfiguration,
-                assetTimeoutConfig,
-                cacheProvider,
-                configuration,
-                appSpecificCacheDir,
-                streamingApi,
-                okHttpClient,
-                okHttpClientWithAuth,
-                gson,
-                eventReporter,
-                streamingPrivileges,
-                uuidWrapper,
-                trueTimeWrapper,
-                playbackPrivilegeProvider,
-                offlinePlayProvider?.offlineCacheProvider,
-                offlinePlayProvider?.encryption,
-                base64Codec,
-                coroutineDispatcher,
-                coroutineScope,
-            )
-            .playbackEngine
+            context,
+            connectivityManager,
+            enableDecoderFallback,
+            events,
+            bufferConfiguration,
+            assetTimeoutConfig,
+            cacheProvider,
+            configuration,
+            appSpecificCacheDir,
+            streamingApi,
+            okHttpClient,
+            okHttpClientWithAuth,
+            gson,
+            eventReporter,
+            streamingPrivileges,
+            uuidWrapper,
+            trueTimeWrapper,
+            playbackPrivilegeProvider,
+            offlinePlayProvider?.offlineCacheProvider,
+            offlinePlayProvider?.encryption,
+            base64Codec,
+            coroutineDispatcher,
+            coroutineScope,
+        )
+
+    @Provides fun playbackEngine(root: PlaybackEngineModuleRoot) = root.playbackEngine
+
+    @Provides
+    fun offlineLicenseProvider(root: PlaybackEngineModuleRoot): OfflineLicenseProvider =
+        root.offlineLicenseProvider
 }

--- a/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
+++ b/player/src/main/kotlin/com/tidal/sdk/player/di/PlayerComponent.kt
@@ -8,6 +8,7 @@ import com.tidal.sdk.player.offlineplay.OfflinePlayProvider
 import com.tidal.sdk.player.playbackengine.PlaybackEngine
 import com.tidal.sdk.player.playbackengine.model.AssetTimeoutConfig
 import com.tidal.sdk.player.playbackengine.model.BufferConfiguration
+import com.tidal.sdk.player.playbackengine.offline.OfflineLicenseProvider
 import com.tidal.sdk.player.playbackengine.playbackprivilege.PlaybackPrivilegeProvider
 import com.tidal.sdk.player.playbackengine.player.CacheProvider
 import com.tidal.sdk.player.streamingapi.StreamingApi
@@ -35,6 +36,7 @@ internal interface PlayerComponent {
 
     val configuration: Configuration
     val playbackEngine: PlaybackEngine
+    val offlineLicenseProvider: OfflineLicenseProvider
     val streamingApi: StreamingApi
     val streamingPrivileges: StreamingPrivileges
 


### PR DESCRIPTION
## Why
Enable the Android app-side Offliner to manage persistent Widevine licenses without moving download orchestration or storage ownership into the SDK.

## What
- Expose acquire, renew, and release operations through `player.offlineLicenseProvider`
- Return Base64-encoded Widevine key-set IDs for app-owned persistence
- Reuse the existing L3 DRM configuration and add focused unit coverage
- Bump the Player module to 0.0.72 and document the public API

## Risk Assessment
Medium — this extends the public Player API and DRM callback modes, but leaves existing streaming behavior unchanged. Builds and tests have not been run locally under the repository working policy.

## References
- [TIDE-2308](https://linear.app/squareup/issue/TIDE-2308/expose-offline-widevine-license-download-api-in-the-sdk-player)

Generated with Codex