### PR TITLE
Initialize tidalapi JSON converters lazily

### DIFF
--- a/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
+++ b/tidalapi/src/main/kotlin/com/tidal/sdk/tidalapi/networking/RetrofitProvider.kt
@@ -40,11 +40,14 @@ constructor(
         }
     }
 
-    private val converterFactories: List<Converter.Factory> =
+    // Built lazily so the ~100+ generated kotlinx.serialization descriptors are initialized on
+    // first request rather than at construction, keeping serializer init off callers' hot paths.
+    private val converterFactories: List<Converter.Factory> by lazy {
         listOf(
             ScalarsConverterFactory.create(),
             createJsonSerializer().asConverterFactory("application/json".toMediaType()),
         )
+    }
 
     private fun provideOkHttpClient(credentialsProvider: CredentialsProvider): OkHttpClient =
         OkHttpClient.Builder()


### PR DESCRIPTION
`RetrofitProvider.converterFactories` was an eager `val`, so constructing the provider synchronously initialized the ~100+ generated kotlinx.serialization descriptors via `getOneOfSerializer()`. Consumers that build the provider on a UI/main thread (e.g. during startup dependency injection) can stall long enough to trigger an ANR — observed in the TIDAL Android app's offline download path, where `StreamingApi` construction ran on the startup main thread.

**What:** make `converterFactories` a `by lazy {}` so descriptor init happens on the first request (always off the caller's construction path) instead of at construction. Behaviour is otherwise unchanged.

**How verified:** pre-commit hook (format/lint) passes; no behavioural change to the converter list contents or ordering.

The app-side mitigation (inject `Lazy<StreamingApi>`) ships in parallel in the client repo; this is the durable fix for all tidalapi consumers.

Refs TM-1908