### PR TITLE
Fix free-form map @Contextual in bundled openapi-generator (TM-1938)

### DIFF
--- a/tidalapi/CHANGELOG.md
+++ b/tidalapi/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Bundled openapi-generator now emits `@Contextual` on free-form map value types (`Map<String, @Contextual Any>`) for kotlinx.serialization, instead of a property-level `@Contextual` the compiler plugin ignores. This replaces a manual post-generation patch and fixes the runtime error "Serializer for element of type kotlin.Any has not been found". (TM-1938)
 
 ## [0.3.54] - 2026-09-03
 ### Changed


### PR DESCRIPTION
## Summary

Fixes TM-1938. Updates the bundled `openapi-generator-cli.jar` so code generation emits `@Contextual` on the **value type** of free-form / `additionalProperties` maps (`Map<String, @Contextual Any>`) instead of a property-level `@Contextual` that the kotlinx.serialization compiler plugin ignores.

Before, regenerating produced:

```kotlin
@Contextual @SerialName(value = "meta")
val meta: kotlin.collections.Map<kotlin.String, kotlin.Any>? = null
```

which crashes at runtime with *"Serializer for element of type kotlin.Any has not been found"*. The correct shape was previously restored by a manual post-generation patch (#359). This change bakes the fix into the generator so regeneration is correct automatically and the manual patch is no longer needed.

## What changed

- Only the bundled `tidalapi/bin/openapi-generator-cli.jar` and the changelog.
- The jar keeps the exact same generator base already in use (commit `81ed019`); only the four `kotlin-client` var templates (`data_class_req_var`, `data_class_opt_var`, `interface_req_var`, `interface_opt_var`) are updated with the fix.
- **No generated source changes**: regenerating the API surface with the new jar yields byte-identical output to the current committed code (the committed code already carries the fixed shape from the manual patch), so this PR contains no `src/` diff — it only makes future regenerations reproduce that shape without hand-editing.

## Validation

- Regenerated `tidalapi` with the new jar → 0 changed source files vs the committed tree; `MutationResponseDocument.meta` renders as `Map<String, @Contextual Any>`.
- Confirmed the reverse: regenerating with the previous jar reverts to the crashing property-level `@Contextual` shape.
- `:tidalapi:compileReleaseKotlin` and `:tidalapi:testDebugUnitTest` pass.

## Upstream

The template fix lives in the Tidal fork: tidal-music/openapi-generator#3. The same bug exists in upstream OpenAPITools; upstreaming is tracked as a follow-up.